### PR TITLE
feat(claude-agent): OAuth governance + mcp_ext link + UI (P4)

### DIFF
--- a/DEPLOYMENT_MCP_GATEWAY.md
+++ b/DEPLOYMENT_MCP_GATEWAY.md
@@ -1,0 +1,372 @@
+# MCP Gateway Deployment Guide
+
+Complete guide to deploy the MCP Gateway service for AgentxSuite.
+
+## 🎯 What You're Deploying
+
+A server-side bridge that allows Claude Desktop users to connect **without installing a local bridge**.
+
+```
+User Flow:
+Claude Desktop → mcp.agentxsuite.com (Gateway) → FastMCP Backend
+```
+
+## 📦 Prerequisites
+
+- Server with Python 3.11+
+- Domain for gateway (e.g., `mcp.agentxsuite.com`)
+- SSL certificate
+- Nginx or similar reverse proxy
+
+## 🚀 Quick Start (Development)
+
+```bash
+# 1. Install dependencies
+cd backend/mcp_gateway
+pip install -r requirements.txt
+
+# 2. Start gateway
+python main.py
+
+# Gateway runs on http://localhost:8091
+
+# 3. Start FastMCP (in another terminal)
+cd backend
+make run-mcp-fabric
+
+# FastMCP runs on http://localhost:8090
+```
+
+**Test it:**
+```bash
+curl http://localhost:8091/health
+# Should return: {"status":"ok","service":"mcp-gateway"}
+```
+
+## 🏭 Production Deployment
+
+### Option 1: Docker (Recommended)
+
+```bash
+# Build image
+cd backend/mcp_gateway
+docker build -t agentxsuite-mcp-gateway .
+
+# Run with docker-compose
+docker-compose up -d
+
+# Check logs
+docker-compose logs -f mcp-gateway
+```
+
+### Option 2: Systemd Service
+
+**1. Create systemd service:**
+
+```bash
+sudo nano /etc/systemd/system/mcp-gateway.service
+```
+
+**Paste:**
+```ini
+[Unit]
+Description=AgentxSuite MCP Gateway
+After=network.target mcp-fabric.service
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/agentxsuite/backend
+Environment="PATH=/opt/agentxsuite/venv/bin"
+Environment="FASTMCP_BACKEND_URL=http://localhost:8090"
+ExecStart=/opt/agentxsuite/venv/bin/python mcp_gateway/main.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**2. Enable and start:**
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable mcp-gateway
+sudo systemctl start mcp-gateway
+sudo systemctl status mcp-gateway
+```
+
+### Option 3: Supervisor
+
+```bash
+sudo nano /etc/supervisor/conf.d/mcp-gateway.conf
+```
+
+```ini
+[program:mcp-gateway]
+command=/opt/agentxsuite/venv/bin/python mcp_gateway/main.py
+directory=/opt/agentxsuite/backend
+user=www-data
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/mcp-gateway.err.log
+stdout_logfile=/var/log/mcp-gateway.out.log
+environment=FASTMCP_BACKEND_URL="http://localhost:8090"
+```
+
+## 🔧 Nginx Configuration
+
+### Basic Setup
+
+```nginx
+upstream mcp_gateway {
+    server localhost:8091;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name mcp.agentxsuite.com;
+
+    ssl_certificate /etc/letsencrypt/live/mcp.agentxsuite.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mcp.agentxsuite.com/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    # SSE endpoint - critical configuration!
+    location /.well-known/mcp/sse {
+        proxy_pass http://mcp_gateway;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Critical for SSE
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        chunked_transfer_encoding off;
+    }
+
+    # WebSocket endpoint
+    location /.well-known/mcp/ws {
+        proxy_pass http://mcp_gateway;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 86400s;
+    }
+
+    # Other endpoints
+    location / {
+        proxy_pass http://mcp_gateway;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    server_name mcp.agentxsuite.com;
+    return 301 https://$server_name$request_uri;
+}
+```
+
+**Apply config:**
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## 🔐 SSL Certificate (Let's Encrypt)
+
+```bash
+# Install certbot
+sudo apt install certbot python3-certbot-nginx
+
+# Get certificate
+sudo certbot --nginx -d mcp.agentxsuite.com
+
+# Auto-renewal is configured automatically
+```
+
+## 📊 Monitoring
+
+### Health Checks
+
+```bash
+# Basic health
+curl https://mcp.agentxsuite.com/health
+
+# SSE endpoint
+curl -N -H "Authorization: Bearer TOKEN" \
+  https://mcp.agentxsuite.com/.well-known/mcp/sse
+```
+
+### Logs
+
+**Docker:**
+```bash
+docker-compose logs -f mcp-gateway
+```
+
+**Systemd:**
+```bash
+journalctl -u mcp-gateway -f
+```
+
+**Supervisor:**
+```bash
+tail -f /var/log/mcp-gateway.out.log
+```
+
+### Metrics
+
+Add to your monitoring (Prometheus, Grafana):
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'mcp-gateway'
+    static_configs:
+      - targets: ['localhost:8091']
+```
+
+## 🧪 Testing
+
+### Test SSE Connection
+
+```bash
+curl -N -H "Authorization: Bearer YOUR_TOKEN" \
+  https://mcp.agentxsuite.com/.well-known/mcp/sse
+```
+
+Should stream events continuously.
+
+### Test WebSocket
+
+```bash
+npm install -g wscat
+
+wscat -c wss://mcp.agentxsuite.com/.well-known/mcp/ws \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Then send:
+{"jsonrpc":"2.0","method":"tools/list","params":{},"id":1}
+```
+
+### Test from Claude Desktop
+
+**Config:**
+```json
+{
+  "mcpServers": {
+    "agentxsuite": {
+      "url": "https://mcp.agentxsuite.com/.well-known/mcp/sse",
+      "transport": "sse",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**Restart Claude Desktop and test!**
+
+## 🚨 Troubleshooting
+
+### Gateway won't start
+
+**Check port 8091:**
+```bash
+lsof -i :8091
+# Kill if needed:
+kill -9 $(lsof -t -i:8091)
+```
+
+**Check backend connection:**
+```bash
+curl http://localhost:8090/health
+# Should work before gateway can
+```
+
+### SSE connection drops
+
+**Check nginx timeout:**
+```nginx
+proxy_read_timeout 86400s;  # 24 hours
+```
+
+**Check system limits:**
+```bash
+ulimit -n  # Should be > 1024
+```
+
+### High memory usage
+
+**Limit connections:**
+```python
+# In mcp_gateway/main.py
+app = FastAPI(
+    ...
+    max_request_size=1024*1024,  # 1MB
+)
+```
+
+## 📈 Scaling
+
+### Load Balancing (Multiple Gateways)
+
+```nginx
+upstream mcp_gateway {
+    least_conn;
+    server gateway1:8091;
+    server gateway2:8091;
+    server gateway3:8091;
+}
+```
+
+### Redis for Session State (Future)
+
+```python
+# For stateful connections
+import redis
+r = redis.Redis(host='localhost', port=6379)
+```
+
+## 🔒 Security Checklist
+
+- [x] HTTPS enforced
+- [x] Token validation on every request
+- [x] Rate limiting configured
+- [x] CORS properly configured
+- [x] Logs don't contain tokens
+- [x] Regular security updates
+- [x] Firewall rules applied
+
+## 📚 Additional Resources
+
+- User Guide: `/docs/USER_GUIDE_MCP_GATEWAY.md`
+- Gateway README: `/backend/mcp_gateway/README.md`
+- FastMCP Docs: https://github.com/jlowin/fastmcp
+
+## 🎉 Success Checklist
+
+- [ ] Gateway health endpoint returns OK
+- [ ] SSE endpoint streams events
+- [ ] Claude Desktop can connect
+- [ ] Tools are callable from Claude
+- [ ] Logs show successful requests
+- [ ] SSL certificate is valid
+- [ ] Monitoring is set up
+
+Congratulations! Your users can now use AgentxSuite **without any local bridge**! 🚀
+

--- a/backend/apps/audit/services.py
+++ b/backend/apps/audit/services.py
@@ -11,9 +11,13 @@ MCP-specific event types:
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING
 
 from libs.logging.context import get_context_ids
+
+if TYPE_CHECKING:
+    from apps.accounts.models import User
+    from apps.tenants.models import Organization
 
 try:
     from opentelemetry import trace
@@ -59,17 +63,23 @@ def log_run_event(
         Created AuditEvent instance
     """
     span = None
+    executable_tool = run.executable_tool
+    tool_id = str(executable_tool.id) if executable_tool else None
+    tool_name = executable_tool.name if executable_tool else "unknown-tool"
+    tool_kind = "curated" if run.curated_tool_id else "raw"
     if OTELEMETRY_AVAILABLE and tracer:
         # Get current span context if available (to link audit events to parent traces)
         current_span = trace.get_current_span()
         span = tracer.start_span(
             f"audit.run.{event_type}",
-            context=current_span.get_span_context() if current_span else None,
+            context=trace.set_span_in_context(current_span) if current_span else None,
         )
         span.set_attribute("audit.event_type", event_type)
         span.set_attribute("run.id", str(run.id))
         span.set_attribute("agent.id", str(run.agent.id))
-        span.set_attribute("tool.id", str(run.tool.id))
+        if tool_id:
+            span.set_attribute("tool.id", tool_id)
+            span.set_attribute("tool.kind", tool_kind)
         span.set_attribute("organization.id", str(run.organization.id))
         span.set_attribute("environment.id", str(run.environment.id))
 
@@ -84,7 +94,9 @@ def log_run_event(
             {
                 "run_id": str(run.id),
                 "agent_id": str(run.agent.id),
-                "tool_id": str(run.tool.id),
+                "tool_id": tool_id,
+                "tool_name": tool_name,
+                "tool_kind": tool_kind,
                 "organization_id": str(run.organization.id),
                 "environment_id": str(run.environment.id),
             }
@@ -126,7 +138,7 @@ def log_run_event(
         # Target: tool identity
         target = data.get("target")
         if not target:
-            target = f"tool:{run.tool.name}"
+            target = f"tool:{tool_name}"
             data["target"] = target
 
         # Decision: infer from event_type
@@ -222,7 +234,7 @@ def log_api_event(
         current_span = trace.get_current_span()
         span = tracer.start_span(
             f"audit.api.{event_type}",
-            context=current_span.get_span_context() if current_span else None,
+            context=trace.set_span_in_context(current_span) if current_span else None,
         )
         span.set_attribute("audit.event_type", event_type)
         if organization:
@@ -364,7 +376,7 @@ def log_security_event(
         current_span = trace.get_current_span()
         span = tracer.start_span(
             f"audit.security.{event_type}",
-            context=current_span.get_span_context() if current_span else None,
+            context=trace.set_span_in_context(current_span) if current_span else None,
         )
         span.set_attribute("audit.event_type", event_type)
         span.set_attribute("organization.id", organization_id)
@@ -477,7 +489,7 @@ def log_api_event(
         current_span = trace.get_current_span()
         span = tracer.start_span(
             f"audit.api.{event_type}",
-            context=current_span.get_span_context() if current_span else None,
+            context=trace.set_span_in_context(current_span) if current_span else None,
         )
         span.set_attribute("audit.event_type", event_type)
         if organization:

--- a/backend/apps/claude_agent/oauth.py
+++ b/backend/apps/claude_agent/oauth.py
@@ -7,13 +7,18 @@ with AgentxSuite's API.
 
 import logging
 import secrets
-from datetime import datetime, timedelta
+import uuid
+from datetime import datetime, timedelta, timezone as datetime_timezone
 from typing import Any
 
+import jwt
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from rest_framework.authtoken.models import Token
+from django.utils import timezone
+
+from apps.agents.services import generate_mcp_token
+from mcp_fabric.settings import MCP_TOKEN_MAX_TTL_MINUTES
 
 User = get_user_model()
 
@@ -26,6 +31,7 @@ class OAuthManager:
     # Cache timeouts
     AUTH_CODE_TIMEOUT = 600  # 10 minutes
     STATE_TOKEN_TIMEOUT = 600  # 10 minutes
+    ACCESS_TOKEN_META_PREFIX = "oauth_token_meta:"
     
     # Valid OAuth scopes
     VALID_SCOPES = {
@@ -43,6 +49,12 @@ class OAuthManager:
         self.client_id = getattr(settings, "CLAUDE_AGENT_CLIENT_ID", "agentxsuite-claude-agent")
         self.client_secret = getattr(settings, "CLAUDE_AGENT_CLIENT_SECRET", None)
         self.redirect_uri = getattr(settings, "CLAUDE_AGENT_REDIRECT_URI", "http://localhost:3000/auth/callback")
+        configured_ttl = getattr(
+            settings,
+            "CLAUDE_AGENT_OAUTH_TOKEN_TTL_MINUTES",
+            MCP_TOKEN_MAX_TTL_MINUTES,
+        )
+        self.access_token_ttl_seconds = max(60, min(int(configured_ttl), MCP_TOKEN_MAX_TTL_MINUTES) * 60)
 
     def generate_authorization_url(
         self, organization_id: str, environment_id: str
@@ -168,34 +180,49 @@ class OAuthManager:
         # Delete code after use (one-time use)
         cache.delete(code_key)
 
-        # Get user and create/retrieve token
+        # Get user and create a short-lived scoped JWT.
         try:
             user = User.objects.get(id=code_data["user_id"])
-            token, created = Token.objects.get_or_create(user=user)
+            jti = str(uuid.uuid4())
+            scope = code_data.get("scope", "agent:execute tools:read")
+            token_string = generate_mcp_token(
+                {
+                    "sub": f"user:{user.id}",
+                    "jti": jti,
+                    "org_id": str(code_data["organization_id"]),
+                    "env_id": str(code_data["environment_id"]),
+                    "scope": scope,
+                    "purpose": "claude_agent_oauth",
+                    "user_id": str(user.id),
+                },
+                expires_in=timedelta(seconds=self.access_token_ttl_seconds),
+            )
 
-            # Store token metadata in cache for later retrieval
-            token_key = f"oauth_token_meta:{token.key}"
+            # Store token metadata by jti only; never persist the bearer token itself.
+            token_key = f"{self.ACCESS_TOKEN_META_PREFIX}{jti}"
             cache.set(
                 token_key,
                 {
                     "organization_id": code_data["organization_id"],
                     "environment_id": code_data["environment_id"],
-                    "scope": code_data.get("scope", "agent:execute tools:read"),
-                    "issued_at": datetime.utcnow().isoformat(),
-                    "user_id": user.id
+                    "scope": scope,
+                    "issued_at": timezone.now().isoformat(),
+                    "user_id": str(user.id),
+                    "jti": jti,
                 },
-                31536000  # 1 year (same as token expiry)
+                self.access_token_ttl_seconds,
             )
 
-            logger.info(f"Exchanged code for token (user={user.id}, token_created={created})")
+            logger.info(f"Exchanged code for short-lived JWT (user={user.id}, jti={jti})")
 
             return {
-                "access_token": token.key,
+                "access_token": token_string,
                 "token_type": "Bearer",
-                "expires_in": 31536000,  # 1 year (tokens don't expire in DRF by default)
+                "expires_in": self.access_token_ttl_seconds,
                 "organization_id": code_data["organization_id"],
                 "environment_id": code_data["environment_id"],
-                "scope": code_data.get("scope", "agent:execute tools:read")
+                "scope": scope,
+                "jti": jti,
             }
 
         except User.DoesNotExist:
@@ -213,19 +240,26 @@ class OAuthManager:
             True if revoked successfully, False otherwise
         """
         try:
-            token = Token.objects.get(key=access_token)
-            user_id = token.user_id
-            token.delete()
-            
-            # Also remove token metadata from cache
-            token_key = f"oauth_token_meta:{access_token}"
+            claims = self._decode_unverified_jwt(access_token)
+            jti = claims.get("jti")
+            if not jti:
+                return False
+
+            metadata = cache.get(f"{self.ACCESS_TOKEN_META_PREFIX}{jti}")
+            if not metadata:
+                return False
+
+            from mcp_fabric.jti_store import revoke_jti
+
+            revoke_jti(jti)
+            token_key = f"{self.ACCESS_TOKEN_META_PREFIX}{jti}"
             cache.delete(token_key)
             
-            logger.info(f"Revoked token for user={user_id}")
+            logger.info(f"Revoked OAuth JWT jti={jti}")
             return True
 
-        except Token.DoesNotExist:
-            logger.warning(f"Attempted to revoke non-existent token")
+        except jwt.PyJWTError:
+            logger.warning("Attempted to revoke invalid OAuth JWT")
             return False
 
     # Request Handler Methods (called by views.py)
@@ -469,26 +503,48 @@ class OAuthManager:
             Token information if valid, None otherwise
         """
         try:
-            token = Token.objects.select_related("user").get(key=access_token)
-            
-            # Get organization and environment from token metadata
-            # (stored when token was issued)
-            token_key = f"oauth_token_meta:{access_token}"
+            claims = self._decode_unverified_jwt(access_token)
+            jti = claims.get("jti")
+            exp = claims.get("exp")
+            if exp is not None and datetime.fromtimestamp(exp, tz=datetime_timezone.utc) <= timezone.now():
+                return None
+
+            if not jti:
+                return None
+
+            token_key = f"{self.ACCESS_TOKEN_META_PREFIX}{jti}"
             metadata = cache.get(token_key)
+            if not metadata:
+                return None
+
+            user = User.objects.get(id=metadata["user_id"])
 
             return {
                 "active": True,
-                "user_id": token.user.id,
-                "username": token.user.username,
-                "email": token.user.email,
-                "organization_id": metadata.get("organization_id") if metadata else None,
-                "environment_id": metadata.get("environment_id") if metadata else None,
-                "scope": metadata.get("scope", "agent:execute tools:read") if metadata else "agent:execute tools:read",
-                "issued_at": token.created.isoformat() if hasattr(token, "created") else None
+                "user_id": str(user.id),
+                "username": user.username,
+                "email": user.email,
+                "organization_id": metadata.get("organization_id"),
+                "environment_id": metadata.get("environment_id"),
+                "scope": metadata.get("scope", "agent:execute tools:read"),
+                "issued_at": metadata.get("issued_at"),
+                "expires_at": datetime.fromtimestamp(exp, tz=datetime_timezone.utc).isoformat()
+                if exp else None,
             }
 
-        except Token.DoesNotExist:
+        except (jwt.PyJWTError, User.DoesNotExist, ValueError, TypeError, OSError):
             return None
+
+    def _decode_unverified_jwt(self, token: str) -> dict[str, Any]:
+        """Decode OAuth JWT claims without verifying signature for cache metadata lookups."""
+        return jwt.decode(
+            token,
+            options={
+                "verify_signature": False,
+                "verify_aud": False,
+                "verify_exp": False,
+            },
+        )
 
     def validate_scopes(self, requested_scopes: list[str]) -> tuple[list[str], list[str]]:
         """
@@ -554,16 +610,19 @@ class OAuthManager:
         if base_url is None:
             base_url = getattr(settings, "OAUTH_AUTHORIZE_URL", "http://localhost:8000")
         
-        auth_url = (
-            f"{base_url}/api/v1/claude-agent/authorize?"
-            f"client_id={self.client_id}&"
-            f"redirect_uri={self.redirect_uri}&"
-            f"response_type=code&"
-            f"state={state}&"
-            f"organization_id={organization_id}&"
-            f"environment_id={environment_id}&"
-            f"scope={'+'.join(self.DEFAULT_SCOPES)}"
-        )
+        # Use proper URL encoding
+        from urllib.parse import urlencode
+        
+        params = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "state": state,
+            "organization_id": organization_id,
+            "environment_id": environment_id,
+            "scope": " ".join(self.DEFAULT_SCOPES),
+        }
+        
+        auth_url = f"{base_url}/api/v1/claude-agent/authorize?{urlencode(params)}"
         
         return {
             "authorization_url": auth_url,

--- a/backend/apps/claude_agent/templates/oauth_authorize.html
+++ b/backend/apps/claude_agent/templates/oauth_authorize.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Authorize Claude Agent - AgentxSuite</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+        .container {
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            max-width: 500px;
+            width: 100%;
+            padding: 40px;
+        }
+        .logo {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+        .logo-icon {
+            width: 64px;
+            height: 64px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border-radius: 12px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 32px;
+            font-weight: bold;
+        }
+        h1 {
+            color: #1a202c;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
+            text-align: center;
+        }
+        .subtitle {
+            color: #718096;
+            font-size: 14px;
+            text-align: center;
+            margin-bottom: 32px;
+        }
+        .info-box {
+            background: #f7fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 24px;
+        }
+        .info-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+        .info-row:last-child {
+            margin-bottom: 0;
+        }
+        .info-label {
+            color: #718096;
+            font-size: 14px;
+        }
+        .info-value {
+            color: #2d3748;
+            font-size: 14px;
+            font-weight: 600;
+        }
+        .scopes-box {
+            background: #f7fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 24px;
+        }
+        .scopes-title {
+            color: #2d3748;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 12px;
+        }
+        .scope-item {
+            display: flex;
+            align-items: flex-start;
+            margin-bottom: 8px;
+        }
+        .scope-item:last-child {
+            margin-bottom: 0;
+        }
+        .scope-icon {
+            color: #48bb78;
+            margin-right: 8px;
+            font-size: 18px;
+        }
+        .scope-text {
+            color: #4a5568;
+            font-size: 14px;
+        }
+        .warning-box {
+            background: #fffaf0;
+            border: 1px solid #fbd38d;
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 24px;
+        }
+        .warning-text {
+            color: #744210;
+            font-size: 13px;
+            line-height: 1.5;
+        }
+        .buttons {
+            display: flex;
+            gap: 12px;
+        }
+        .button {
+            flex: 1;
+            padding: 12px 24px;
+            border: none;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .button-primary {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+        .button-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 20px rgba(102, 126, 234, 0.3);
+        }
+        .button-secondary {
+            background: #e2e8f0;
+            color: #4a5568;
+        }
+        .button-secondary:hover {
+            background: #cbd5e0;
+        }
+        .error-box {
+            background: #fff5f5;
+            border: 1px solid #fc8181;
+            border-radius: 8px;
+            padding: 16px;
+            margin-bottom: 24px;
+        }
+        .error-text {
+            color: #c53030;
+            font-size: 14px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="logo">
+            <div class="logo-icon">Ax</div>
+        </div>
+        
+        <h1>Authorize Claude Agent</h1>
+        <p class="subtitle">Grant access to your AgentxSuite tools and capabilities</p>
+        
+        {% if error %}
+        <div class="error-box">
+            <p class="error-text">{{ error }}</p>
+        </div>
+        {% else %}
+        
+        <div class="info-box">
+            <div class="info-row">
+                <span class="info-label">Application</span>
+                <span class="info-value">Claude Hosted Agent</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Organization</span>
+                <span class="info-value">{{ organization_name }}</span>
+            </div>
+            <div class="info-row">
+                <span class="info-label">Environment</span>
+                <span class="info-value">{{ environment_name }}</span>
+            </div>
+        </div>
+        
+        <div class="scopes-box">
+            <div class="scopes-title">This application will be able to:</div>
+            {% for scope in scopes %}
+            <div class="scope-item">
+                <span class="scope-icon">✓</span>
+                <span class="scope-text">{{ scope }}</span>
+            </div>
+            {% endfor %}
+        </div>
+        
+        <div class="warning-box">
+            <p class="warning-text">
+                ⚠️ Only authorize applications you trust. This will grant Claude agents 
+                access to execute tools and read data in your organization.
+            </p>
+        </div>
+        
+        <form method="post" action="{{ authorize_url }}">
+            {% csrf_token %}
+            <input type="hidden" name="client_id" value="{{ client_id }}">
+            <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
+            <input type="hidden" name="response_type" value="{{ response_type }}">
+            <input type="hidden" name="state" value="{{ state }}">
+            <input type="hidden" name="scope" value="{{ scope }}">
+            <input type="hidden" name="organization_id" value="{{ organization_id }}">
+            <input type="hidden" name="environment_id" value="{{ environment_id }}">
+            <input type="hidden" name="approve" value="true">
+            
+            <div class="buttons">
+                <button type="button" class="button button-secondary" onclick="window.close()">
+                    Cancel
+                </button>
+                <button type="submit" class="button button-primary">
+                    Authorize
+                </button>
+            </div>
+        </form>
+        {% endif %}
+    </div>
+</body>
+</html>
+

--- a/backend/apps/claude_agent/templates/oauth_login.html
+++ b/backend/apps/claude_agent/templates/oauth_login.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - AgentxSuite OAuth</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+        .container {
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            max-width: 400px;
+            width: 100%;
+            padding: 40px;
+        }
+        .logo {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+        .logo-icon {
+            width: 64px;
+            height: 64px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border-radius: 12px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 32px;
+            font-weight: bold;
+        }
+        h1 {
+            color: #1a202c;
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
+            text-align: center;
+        }
+        .subtitle {
+            color: #718096;
+            font-size: 14px;
+            text-align: center;
+            margin-bottom: 32px;
+        }
+        .form-group {
+            margin-bottom: 20px;
+        }
+        label {
+            display: block;
+            color: #2d3748;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+        input[type="text"],
+        input[type="email"],
+        input[type="password"] {
+            width: 100%;
+            padding: 12px;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            font-size: 14px;
+            transition: border-color 0.2s;
+        }
+        input[type="text"]:focus,
+        input[type="email"]:focus,
+        input[type="password"]:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        }
+        .button {
+            width: 100%;
+            padding: 12px 24px;
+            border: none;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+        .button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 20px rgba(102, 126, 234, 0.3);
+        }
+        .button:active {
+            transform: translateY(0);
+        }
+        .error-box {
+            background: #fff5f5;
+            border: 1px solid #fc8181;
+            border-radius: 8px;
+            padding: 12px;
+            margin-bottom: 20px;
+        }
+        .error-text {
+            color: #c53030;
+            font-size: 14px;
+        }
+        .info-box {
+            background: #ebf8ff;
+            border: 1px solid #90cdf4;
+            border-radius: 8px;
+            padding: 12px;
+            margin-bottom: 20px;
+        }
+        .info-text {
+            color: #2c5282;
+            font-size: 13px;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="logo">
+            <div class="logo-icon">Ax</div>
+        </div>
+        
+        <h1>Sign In</h1>
+        <p class="subtitle">Login to authorize Claude Agent</p>
+        
+        {% if error %}
+        <div class="error-box">
+            <p class="error-text">{{ error }}</p>
+        </div>
+        {% endif %}
+        
+        <div class="info-box">
+            <p class="info-text">
+                🔐 You need to sign in to authorize Claude agents to access your AgentxSuite tools.
+            </p>
+        </div>
+        
+        <form method="post" action="{{ login_url }}">
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{{ next_url }}">
+            
+            <div class="form-group">
+                <label for="username">Email or Username</label>
+                <input 
+                    type="text" 
+                    id="username" 
+                    name="username" 
+                    required 
+                    autofocus 
+                    placeholder="admin@example.com"
+                >
+            </div>
+            
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input 
+                    type="password" 
+                    id="password" 
+                    name="password" 
+                    required
+                    placeholder="Enter your password"
+                >
+            </div>
+            
+            <button type="submit" class="button">
+                Sign In
+            </button>
+        </form>
+    </div>
+</body>
+</html>
+

--- a/backend/apps/claude_agent/tests/test_oauth.py
+++ b/backend/apps/claude_agent/tests/test_oauth.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
+import jwt
+
 from apps.claude_agent.oauth import OAuthManager
 
 User = get_user_model()
@@ -60,8 +62,19 @@ class OAuthManagerTests(TestCase):
         
         self.assertIsNotNone(token_data)
         self.assertIn("access_token", token_data)
+        self.assertLessEqual(token_data["expires_in"], 1800)
         self.assertEqual(token_data["organization_id"], self.org_id)
         self.assertEqual(token_data["environment_id"], self.env_id)
+
+        claims = jwt.decode(
+            token_data["access_token"],
+            options={"verify_signature": False, "verify_exp": False},
+        )
+        self.assertEqual(claims["org_id"], self.org_id)
+        self.assertEqual(claims["env_id"], self.env_id)
+        self.assertEqual(claims["scope"], "agent:execute tools:read")
+        self.assertEqual(claims["purpose"], "claude_agent_oauth")
+        self.assertIn("jti", claims)
         
         # 3. Verify code is consumed (cannot be used twice)
         second_attempt = self.manager.exchange_code_for_token(code)
@@ -73,10 +86,12 @@ class OAuthManagerTests(TestCase):
         code = self.manager.generate_authorization_code(self.user, self.org_id, self.env_id)
         token_data = self.manager.exchange_code_for_token(code)
         access_token = token_data["access_token"]
+        self.assertIsNotNone(self.manager.get_access_info(access_token))
         
         # 2. Revoke it
         success = self.manager.revoke_token(access_token)
         self.assertTrue(success)
+        self.assertIsNone(self.manager.get_access_info(access_token))
         
         # 3. Try to revoke again (should fail or return False depending on impl, here False)
         success_again = self.manager.revoke_token(access_token)

--- a/backend/apps/claude_agent/urls.py
+++ b/backend/apps/claude_agent/urls.py
@@ -12,6 +12,8 @@ urlpatterns = [
     path("openapi.json", views.openapi_spec, name="openapi"),
     
     # OAuth flow
+    path("oauth/initiate", views.oauth_initiate, name="oauth_initiate"),
+    path("login", views.oauth_login, name="oauth_login"),
     path("authorize", views.oauth_authorize, name="authorize"),
     path("token", views.oauth_token, name="token"),
     path("revoke", views.oauth_revoke, name="revoke"),

--- a/backend/apps/claude_agent/views.py
+++ b/backend/apps/claude_agent/views.py
@@ -1,6 +1,7 @@
 """API views for Claude Agent SDK integration."""
 
 import logging
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.utils import timezone
@@ -448,6 +449,57 @@ def execute_agent(request: Request) -> Response:
         )
 
 
+@api_view(["GET", "POST"])
+@permission_classes([AllowAny])
+def oauth_login(request: Request):
+    """
+    Custom login page for OAuth flow.
+    
+    GET: Displays login form
+    POST: Processes login and redirects to authorization page
+    """
+    from django.shortcuts import render, redirect
+    from django.contrib.auth import authenticate, login
+    from urllib.parse import unquote
+    
+    next_url = request.GET.get("next", "/api/v1/claude-agent/authorize")
+    
+    if request.method == "GET":
+        # User is already authenticated
+        if request.user.is_authenticated:
+            return redirect(next_url)
+        
+        # Display login form
+        return render(request, "oauth_login.html", {
+            "next_url": next_url,
+            "login_url": request.path,
+        })
+    
+    else:  # POST - Process login
+        username = request.POST.get("username")
+        password = request.POST.get("password")
+        next_url = request.POST.get("next", "/api/v1/claude-agent/authorize")
+        
+        # Authenticate user
+        user = authenticate(request, username=username, password=password)
+        
+        if user is not None:
+            # Login successful
+            login(request, user)
+            logger.info(f"OAuth login successful for user: {username}")
+            
+            # Redirect to the authorization page
+            return redirect(next_url)
+        else:
+            # Login failed
+            logger.warning(f"OAuth login failed for user: {username}")
+            return render(request, "oauth_login.html", {
+                "error": "Invalid username or password",
+                "next_url": next_url,
+                "login_url": request.path,
+            })
+
+
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def health_check(request: Request) -> Response:
@@ -493,23 +545,228 @@ def health_check(request: Request) -> Response:
 
 # OAuth Endpoints
 
-@api_view(["GET"])
+@api_view(["POST"])
 @permission_classes([AllowAny])
-def oauth_authorize(request: Request) -> Response:
+def oauth_initiate(request: Request) -> Response:
     """
-    OAuth 2.0 authorization endpoint.
+    Initiate OAuth flow by generating state and authorization URL.
     
-    Initiates the OAuth flow for Claude hosted agents.
+    This endpoint should be called before redirecting to the authorization page.
+    It generates a secure state token and stores it in the cache.
     """
     try:
-        result = oauth_manager.authorize(request)
-        return Response(result)
+        organization_id = request.data.get("organization_id")
+        environment_id = request.data.get("environment_id")
+        scopes = request.data.get("scopes", oauth_manager.DEFAULT_SCOPES)
+        redirect_uri = request.data.get("redirect_uri")
+        
+        if not organization_id or not environment_id:
+            return Response(
+                {"error": "organization_id and environment_id are required"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        
+        # Generate state and authorization URL
+        base_url = request.build_absolute_uri('/')[:-1]
+        result = oauth_manager.initiate_flow(
+            organization_id=organization_id,
+            environment_id=environment_id,
+            base_url=base_url
+        )
+        
+        # Add redirect_uri and scopes to the URL if provided
+        from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+        
+        parsed_url = urlparse(result["authorization_url"])
+        params = parse_qs(parsed_url.query)
+        
+        # Add/override redirect_uri if provided
+        if redirect_uri:
+            params["redirect_uri"] = [redirect_uri]
+        
+        # Add scopes if provided
+        if scopes:
+            scope_str = " ".join(scopes) if isinstance(scopes, list) else scopes
+            params["scope"] = [scope_str]
+        
+        # Rebuild URL with updated params (no duplicates)
+        new_query = urlencode(params, doseq=True)
+        auth_url = urlunparse((
+            parsed_url.scheme,
+            parsed_url.netloc,
+            parsed_url.path,
+            parsed_url.params,
+            new_query,
+            parsed_url.fragment
+        ))
+        
+        return Response({
+            "authorization_url": auth_url,
+            "state": result["state"],
+            "expires_at": (datetime.now() + timedelta(seconds=oauth_manager.STATE_TOKEN_TIMEOUT)).isoformat()
+        })
     except Exception as e:
-        logger.error(f"OAuth authorization failed: {e}", exc_info=True)
+        logger.error(f"OAuth initiation failed: {e}", exc_info=True)
         return Response(
             {"error": str(e)},
             status=status.HTTP_400_BAD_REQUEST
         )
+
+
+@api_view(["GET", "POST"])
+@permission_classes([AllowAny])
+def oauth_authorize(request: Request):
+    """
+    OAuth 2.0 authorization endpoint.
+    
+    GET: Displays authorization page where users approve access.
+    POST: Processes the authorization and redirects with code.
+    """
+    from django.shortcuts import render, redirect
+    from django.urls import reverse
+    from urllib.parse import urlencode, quote
+    
+    try:
+        if request.method == "GET":
+            # Extract parameters
+            client_id = request.GET.get("client_id")
+            redirect_uri = request.GET.get("redirect_uri")
+            response_type = request.GET.get("response_type", "code")
+            state = request.GET.get("state")
+            scope = request.GET.get("scope", "")
+            organization_id = request.GET.get("organization_id")
+            environment_id = request.GET.get("environment_id")
+            
+            # Check if user is authenticated FIRST
+            if not request.user.is_authenticated:
+                # Store OAuth parameters in session before redirecting to login
+                if all([client_id, state, organization_id, environment_id]):
+                    request.session["oauth_params"] = {
+                        "client_id": client_id,
+                        "redirect_uri": redirect_uri,
+                        "response_type": response_type,
+                        "state": state,
+                        "scope": scope,
+                        "organization_id": organization_id,
+                        "environment_id": environment_id,
+                    }
+                    request.session.modified = True  # Force session save
+                
+                # Check if request has valid token in Authorization header or cookies
+                # This allows users who are already logged in via frontend to proceed
+                auth_header = request.META.get('HTTP_AUTHORIZATION', '')
+                if auth_header.startswith('Token '):
+                    # User has token from frontend - try to authenticate
+                    from rest_framework.authtoken.models import Token
+                    token_key = auth_header.split(' ')[1]
+                    try:
+                        token = Token.objects.get(key=token_key)
+                        # Manually set the user (DRF authentication)
+                        request.user = token.user
+                        # Continue with authorization (don't redirect to login)
+                    except Token.DoesNotExist:
+                        pass
+                
+                # Still not authenticated - redirect to login
+                if not request.user.is_authenticated:
+                    login_url = f"/api/v1/claude-agent/login?next={quote(request.get_full_path())}"
+                    return redirect(login_url)
+            
+            # User is authenticated - check if parameters are missing (after login redirect)
+            if not all([client_id, redirect_uri, state, organization_id, environment_id]):
+                # Try to restore from session
+                if "oauth_params" in request.session:
+                    oauth_params = request.session.pop("oauth_params", {})
+                    client_id = oauth_params.get("client_id")
+                    redirect_uri = oauth_params.get("redirect_uri")
+                    response_type = oauth_params.get("response_type", "code")
+                    state = oauth_params.get("state")
+                    scope = oauth_params.get("scope", "")
+                    organization_id = oauth_params.get("organization_id")
+                    environment_id = oauth_params.get("environment_id")
+                    
+                    # Verify we got all required params from session
+                    if not all([client_id, redirect_uri, state, organization_id, environment_id]):
+                        return render(request, "oauth_authorize.html", {
+                            "error": "Session expired. Please start the authorization flow again from the frontend."
+                        })
+                else:
+                    return render(request, "oauth_authorize.html", {
+                        "error": "Missing required parameters. Please start the authorization flow again from the frontend."
+                    })
+            
+            # Get organization and environment info
+            from apps.tenants.models import Organization, Environment
+            try:
+                org = Organization.objects.get(id=organization_id)
+                env = Environment.objects.get(id=environment_id, organization=org)
+                
+                # Check if user has access
+                if not org.members.filter(id=request.user.id).exists():
+                    return render(request, "oauth_authorize.html", {
+                        "error": "You do not have access to this organization"
+                    })
+            except (Organization.DoesNotExist, Environment.DoesNotExist):
+                return render(request, "oauth_authorize.html", {
+                    "error": "Organization or Environment not found"
+                })
+            
+            # Parse scopes
+            scopes = scope.split() if scope else oauth_manager.DEFAULT_SCOPES
+            scope_descriptions = [oauth_manager.VALID_SCOPES.get(s, s) for s in scopes]
+            
+            # Render authorization page
+            return render(request, "oauth_authorize.html", {
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "response_type": response_type,
+                "state": state,
+                "scope": scope,
+                "organization_id": organization_id,
+                "environment_id": environment_id,
+                "organization_name": org.name,
+                "environment_name": env.name,
+                "scopes": scope_descriptions,
+                "authorize_url": request.get_full_path(),
+            })
+        
+        else:  # POST - User approved
+            # Extract parameters from form
+            client_id = request.POST.get("client_id")
+            redirect_uri = request.POST.get("redirect_uri")
+            state = request.POST.get("state")
+            organization_id = request.POST.get("organization_id")
+            environment_id = request.POST.get("environment_id")
+            approve = request.POST.get("approve")
+            
+            if not approve:
+                # User denied authorization
+                error_params = urlencode({
+                    "error": "access_denied",
+                    "error_description": "User denied authorization",
+                    "state": state
+                })
+                return redirect(f"{redirect_uri}?{error_params}")
+            
+            # Generate authorization code
+            auth_code = oauth_manager.generate_authorization_code(
+                user=request.user,
+                organization_id=organization_id,
+                environment_id=environment_id
+            )
+            
+            # Redirect to callback with code
+            callback_params = urlencode({
+                "code": auth_code,
+                "state": state
+            })
+            return redirect(f"{redirect_uri}?{callback_params}")
+            
+    except Exception as e:
+        logger.error(f"OAuth authorization failed: {e}", exc_info=True)
+        return render(request, "oauth_authorize.html", {
+            "error": str(e)
+        })
 
 
 @api_view(["POST"])

--- a/backend/apps/mcp_ext/migrations/0005_mcpserverregistration_connection.py
+++ b/backend/apps/mcp_ext/migrations/0005_mcpserverregistration_connection.py
@@ -1,0 +1,67 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def sync_existing_registrations(apps, schema_editor):
+    MCPServerRegistration = apps.get_model("mcp_ext", "MCPServerRegistration")
+    Connection = apps.get_model("connections", "Connection")
+
+    for registration in MCPServerRegistration.objects.filter(connection__isnull=True):
+        if registration.server_type == "stdio":
+            transport = "stdio"
+        elif registration.server_type == "ws":
+            transport = "sse"
+        else:
+            transport = "streamable_http"
+
+        if registration.auth_method in {"none", "bearer", "basic"}:
+            auth_method = registration.auth_method
+        else:
+            auth_method = "bearer" if registration.secret_ref else "none"
+
+        metadata = registration.metadata if isinstance(registration.metadata, dict) else {}
+        egress_allowlist = metadata.get("egress_allowlist") or []
+        env_ref = metadata.get("env_ref")
+
+        connection, _created = Connection.objects.update_or_create(
+            organization_id=registration.organization_id,
+            environment_id=registration.environment_id,
+            name=registration.slug,
+            defaults={
+                "transport": transport,
+                "endpoint": registration.endpoint or None,
+                "command": registration.command,
+                "args": registration.args or [],
+                "env_ref": env_ref,
+                "auth_method": auth_method,
+                "secret_ref": registration.secret_ref or None,
+                "egress_allowlist": egress_allowlist,
+                "status": "unknown",
+            },
+        )
+        registration.connection_id = connection.id
+        registration.save(update_fields=["connection"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("connections", "0003_connection_egress_allowlist"),
+        ("mcp_ext", "0004_rename_mcp_ext_hu_full_na_idx_mcp_ext_hub_full_na_faf168_idx_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="mcpserverregistration",
+            name="connection",
+            field=models.OneToOneField(
+                blank=True,
+                help_text="Canonical AgentxSuite connection backing this legacy registration.",
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="mcp_server_registration",
+                to="connections.connection",
+            ),
+        ),
+        migrations.RunPython(sync_existing_registrations, migrations.RunPython.noop),
+    ]

--- a/backend/apps/mcp_ext/models.py
+++ b/backend/apps/mcp_ext/models.py
@@ -145,6 +145,14 @@ class MCPServerRegistration(TimeStamped):
         related_name="mcp_servers",
         help_text="Environment this server is available in",
     )
+    connection = models.OneToOneField(
+        "connections.Connection",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="mcp_server_registration",
+        help_text="Canonical AgentxSuite connection backing this legacy registration.",
+    )
 
     # Server metadata
     name = models.CharField(
@@ -246,20 +254,100 @@ class MCPServerRegistration(TimeStamped):
         """Validate model constraints."""
         from django.core.exceptions import ValidationError
 
+        errors = {}
+
         # Validate server type specific fields
         if self.server_type == self.ServerType.STDIO:
             if not self.command:
-                raise ValidationError({"command": "Command is required for stdio servers"})
+                errors["command"] = "Command is required for stdio servers"
         elif self.server_type in [self.ServerType.HTTP, self.ServerType.WEBSOCKET]:
             if not self.endpoint:
-                raise ValidationError({"endpoint": "Endpoint is required for HTTP/WebSocket servers"})
+                errors["endpoint"] = "Endpoint is required for HTTP/WebSocket servers"
 
         # Validate environment belongs to organization
         if self.environment and self.organization:
             if self.environment.organization_id != self.organization_id:
-                raise ValidationError(
-                    {"environment": "Environment must belong to the selected organization"}
-                )
+                errors["environment"] = "Environment must belong to the selected organization"
+
+        egress_allowlist = self.metadata.get("egress_allowlist") if isinstance(self.metadata, dict) else None
+        if egress_allowlist is not None and (
+            not isinstance(egress_allowlist, list)
+            or not all(isinstance(entry, str) for entry in egress_allowlist)
+        ):
+            errors["metadata"] = "metadata.egress_allowlist must be a list of strings"
+
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, sync_connection: bool = True, **kwargs):
+        """Persist the legacy registration and keep its canonical Connection in sync."""
+        super().save(*args, **kwargs)
+        if not sync_connection:
+            return
+
+        connection = self.sync_to_connection()
+        if self.connection_id != connection.id:
+            type(self).objects.filter(pk=self.pk).update(connection=connection)
+            self.connection = connection
+
+    def sync_to_connection(self):
+        """Create or update the canonical Connection backing this registration."""
+        from apps.connections.models import Connection
+
+        defaults = {
+            "transport": self._connection_transport(),
+            "endpoint": self.endpoint or None,
+            "command": self.command,
+            "args": self.args or [],
+            "env_ref": self.metadata.get("env_ref") if isinstance(self.metadata, dict) else None,
+            "auth_method": self._connection_auth_method(),
+            "secret_ref": self.secret_ref or None,
+            "egress_allowlist": self._connection_egress_allowlist(),
+            "status": self._connection_status(),
+        }
+
+        if self.connection_id:
+            Connection.objects.filter(pk=self.connection_id).update(**defaults)
+            return Connection.objects.get(pk=self.connection_id)
+
+        connection, _created = Connection.objects.update_or_create(
+            organization=self.organization,
+            environment=self.environment,
+            name=self.slug,
+            defaults=defaults,
+        )
+        return connection
+
+    def _connection_transport(self):
+        """Map legacy registration server types to Connection transports."""
+        from apps.connections.models import Connection
+
+        if self.server_type == self.ServerType.STDIO:
+            return Connection.Transport.STDIO
+        if self.server_type == self.ServerType.WEBSOCKET:
+            return Connection.Transport.SSE
+        return Connection.Transport.STREAMABLE_HTTP
+
+    def _connection_auth_method(self) -> str:
+        """Map registration auth methods to Connection auth methods."""
+        if self.auth_method in {"none", "bearer", "basic"}:
+            return self.auth_method
+        return "bearer" if self.secret_ref else "none"
+
+    def _connection_egress_allowlist(self) -> list[str]:
+        """Read HTTP egress allowlist from metadata for the canonical Connection."""
+        if not isinstance(self.metadata, dict):
+            return []
+        allowlist = self.metadata.get("egress_allowlist") or []
+        return [str(entry) for entry in allowlist]
+
+    def _connection_status(self) -> str:
+        """Translate registration health status to Connection status."""
+        if self.health_status == "healthy":
+            return "ok"
+        if self.health_status == "unhealthy":
+            return "fail"
+        return "unknown"
 
 
 class MCPHubServer(TimeStamped):

--- a/backend/apps/mcp_ext/serializers.py
+++ b/backend/apps/mcp_ext/serializers.py
@@ -89,6 +89,7 @@ class MCPServerRegistrationSerializer(serializers.ModelSerializer):
     organization = OrganizationSerializer(read_only=True)
     environment = EnvironmentSerializer(read_only=True)
     environment_id = serializers.UUIDField(write_only=True, required=False)
+    connection_id = serializers.UUIDField(source="connection.id", read_only=True)
     args = serializers.JSONField(required=False, allow_null=False)
     env_vars = serializers.JSONField(required=False, allow_null=False)
     tags = serializers.JSONField(required=False, allow_null=False)
@@ -101,6 +102,7 @@ class MCPServerRegistrationSerializer(serializers.ModelSerializer):
             "organization",
             "environment",
             "environment_id",
+            "connection_id",
             "name",
             "slug",
             "description",

--- a/backend/apps/mcp_ext/tests/test_mcp_server_registration.py
+++ b/backend/apps/mcp_ext/tests/test_mcp_server_registration.py
@@ -7,6 +7,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from rest_framework.test import APIClient
 
+from apps.connections.models import Connection
 from apps.mcp_ext.models import MCPServerRegistration
 from apps.tenants.models import Environment, Organization
 
@@ -89,6 +90,9 @@ class TestMCPServerRegistrationModel:
         assert server.server_type == MCPServerRegistration.ServerType.HTTP
         assert server.endpoint == "https://example.com/.well-known/mcp"
         assert server.enabled is True
+        assert server.connection is not None
+        assert server.connection.transport == Connection.Transport.STREAMABLE_HTTP
+        assert server.connection.endpoint == "https://example.com/.well-known/mcp"
         assert str(server) == f"{org.name}/{environment.name}/test-http"
 
     @pytest.mark.django_db
@@ -110,6 +114,28 @@ class TestMCPServerRegistrationModel:
         assert server.command == "python"
         assert server.args == ["-m", "my_mcp_server"]
         assert server.env_vars == {"API_KEY": "secret://my-api-key"}
+        assert server.connection is not None
+        assert server.connection.transport == Connection.Transport.STDIO
+        assert server.connection.command == "python"
+        assert server.connection.args == ["-m", "my_mcp_server"]
+
+    @pytest.mark.django_db
+    def test_registration_syncs_egress_allowlist_to_connection(self, org, environment):
+        """Legacy MCP registrations keep Connection as the canonical outbound config."""
+        server = MCPServerRegistration.objects.create(
+            organization=org,
+            environment=environment,
+            name="Allowed HTTP Server",
+            slug="allowed-http",
+            server_type=MCPServerRegistration.ServerType.HTTP,
+            endpoint="https://api.example.com/mcp",
+            metadata={"egress_allowlist": ["api.example.com"]},
+            enabled=True,
+        )
+
+        assert server.connection is not None
+        assert server.connection.name == "allowed-http"
+        assert server.connection.egress_allowlist == ["api.example.com"]
 
     @pytest.mark.django_db
     def test_unique_slug_per_org_env(self, org, environment):

--- a/backend/apps/mcp_ext/views.py
+++ b/backend/apps/mcp_ext/views.py
@@ -173,17 +173,33 @@ class MCPServerRegistrationViewSet(AuditLoggingMixin, ModelViewSet):
         
         This will update the health_status, health_message, and last_health_check fields.
         """
+        from apps.connections.services import test_connection
+        from django.utils import timezone
+
         server = self.get_object()
-        
-        # TODO: Implement actual health check logic based on server_type
-        # For now, just mark as pending implementation
+        connection = server.sync_to_connection()
+        test_connection(connection)
+
+        server.health_status = "healthy" if connection.status == "ok" else "unhealthy"
+        server.health_message = (
+            "Canonical connection health check succeeded"
+            if connection.status == "ok"
+            else "Canonical connection health check failed"
+        )
+        server.last_health_check = timezone.now()
+        server.save(
+            update_fields=["health_status", "health_message", "last_health_check"],
+            sync_connection=False,
+        )
+
         return Response(
             {
                 "id": str(server.id),
                 "slug": server.slug,
                 "health_status": server.health_status,
-                "health_message": "Health check not yet implemented",
+                "health_message": server.health_message,
                 "last_health_check": server.last_health_check,
+                "connection_id": str(connection.id),
             }
         )
 
@@ -221,15 +237,17 @@ class MCPServerRegistrationViewSet(AuditLoggingMixin, ModelViewSet):
         
         config = {"mcpServers": {}}
         
-        # 1. Add AgentxSuite as primary MCP server (with HTTP bridge)
-        # Using HTTP bridge instead of stdio adapter to avoid database/path issues
+        # 1. Add AgentxSuite as primary MCP server (via HTTP Bridge)
+        # Claude Desktop requires a local process (stdio) even for HTTP/SSE connections.
+        # It spawns a client process that translates stdio to HTTP.
+        
         token_string = self._get_token_from_request(request)
-        
-        # Get MCP Fabric Base URL
         from mcp_fabric.deps import MCP_FABRIC_BASE_URL
-        mcp_fabric_url = f"{MCP_FABRIC_BASE_URL.rstrip('/')}/.well-known/mcp"
         
-        # Get path to mcp-http-bridge.js (relative to project root)
+        # Use the base MCP endpoint (not /sse, the bridge handles that)
+        mcp_base_url = f"{MCP_FABRIC_BASE_URL.rstrip('/')}/.well-known/mcp"
+        
+        # Get absolute path to mcp-http-bridge.js
         from pathlib import Path
         project_root = Path(__file__).resolve().parent.parent.parent.parent
         bridge_path = project_root / "docs" / "mcp-http-bridge.js"
@@ -237,16 +255,14 @@ class MCPServerRegistrationViewSet(AuditLoggingMixin, ModelViewSet):
         config["mcpServers"]["agentxsuite"] = {
             "command": "node",
             "args": [
-                str(bridge_path),
-                mcp_fabric_url,
+                str(bridge_path.resolve()),  # Ensure absolute path
+                mcp_base_url,
                 "--header",
                 f"Authorization: Bearer {token_string}",
             ],
             "env": {
                 "DEBUG": "1",
             },
-            # Optional: Add comment for user
-            "_comment": "AgentxSuite MCP Server (HTTP bridge)",
         }
         
         # 2. Add registered external MCP servers

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -7,9 +7,11 @@ from django.contrib import admin
 from django.urls import include, path
 
 from apps.claude_agent import views as claude_views
+from config.openapi import openapi_schema
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/schema/", openapi_schema, name="api_schema"),
     
     # Well-known endpoints for service discovery
     path(".well-known/agent-manifest", claude_views.wellknown_agent_manifest, name="wellknown_agent_manifest"),

--- a/backend/mcp_fabric/adapters.py
+++ b/backend/mcp_fabric/adapters.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from apps.agents.models import Agent
-from apps.runs.services import start_run
+from apps.runs.services import ExecutionContext, execute_tool_run
 from apps.tools.models import Tool
-from mcp_fabric.pep import check_policy_before_tool_call
 
 logger = logging.getLogger(__name__)
 
@@ -42,14 +40,8 @@ def run_tool_via_agentxsuite(
         - {"status": "success", "output": {...}, "run_id": "..."}
         - {"status": "error", "error": "error_code", "run_id": "..."}
     """
-    # P0: Use resolved agent_id (from token via subject/issuer mapping)
-    # token_agent_id is now the resolved agent_id from deps (source of truth)
-    # agent_id from payload/query must match or be None
-    
-    final_agent_id = token_agent_id  # Use resolved agent_id (source of truth)
-    
     # If agent_id provided in payload/query, it must match resolved agent_id
-    if agent_id and agent_id != token_agent_id:
+    if agent_id and token_agent_id and agent_id != token_agent_id:
         logger.warning(
             f"Agent ID mismatch: resolved agent_id is '{token_agent_id}' but request specifies '{agent_id}'",
             extra={
@@ -68,96 +60,59 @@ def run_tool_via_agentxsuite(
                 "Agent cannot be changed during session."
             ),
         }
-    
-    # Determine agent (must use resolved agent_id)
-    if final_agent_id:
-        agent = Agent.objects.filter(
+
+    # Execute through the unified service; start_run is the single PDP-backed gate.
+    try:
+        result = execute_tool_run(
             organization=tool.organization,
             environment=tool.environment,
-            id=final_agent_id,
-            enabled=True,
-        ).first()
-        if not agent:
-            logger.warning(
-                f"Agent {final_agent_id} not found for tool {tool.name}",
-                extra={
-                    "tool_id": str(tool.id),
-                    "agent_id": final_agent_id,
-                    "org_id": str(tool.organization.id),
-                    "env_id": str(tool.environment.id),
-                },
-            )
-            return {"status": "error", "error": "agent_not_found"}
-    else:
-        agent = (
-            Agent.objects.filter(
-                organization=tool.organization,
-                environment=tool.environment,
-                enabled=True,
-            )
-            .order_by("-created_at")
-            .first()
+            tool_identifier=str(tool.id),
+            agent_identifier=agent_id,
+            input_data=payload,
+            context=ExecutionContext(
+                token_agent_id=token_agent_id,
+                jti=jti,
+                client_ip=client_ip,
+                request_id=request_id,
+            ),
+            timeout_seconds=30,
         )
-        if not agent:
-            logger.warning(
-                f"No active agent found for tool {tool.name}",
-                extra={
-                    "tool_id": str(tool.id),
-                    "org_id": str(tool.organization.id),
-                    "env_id": str(tool.environment.id),
-                },
-            )
-            return {"status": "error", "error": "no_active_agent"}
 
-    # PEP: Policy Enforcement Point - check policy BEFORE tool execution (deny-by-default)
-    # P0: Pass audit metadata (jti, ip, request_id) for forensics
-    allowed, deny_reason = check_policy_before_tool_call(
-        agent_id=str(agent.id),
-        tool=tool,
-        payload=payload,
-        jti=jti,
-        client_ip=client_ip,
-        request_id=request_id,
-    )
-    if not allowed:
-        logger.warning(
-            f"PEP denied tool execution: {tool.name}",
-            extra={
-                "agent_id": str(agent.id),
-                "tool_id": str(tool.id),
-                "reason": deny_reason,
-            },
-        )
-        return {
-            "status": "error",
-            "error": "policy_denied",
-            "error_description": deny_reason or "Policy denied",
-        }
-
-    # Start run (uses our security: Policy, Schema, Rate, Timeout, Audit)
-    # Note: start_run also checks policy, but PEP check is explicit for MCP calls
-    try:
-        run = start_run(agent=agent, tool=tool, input_json=payload, timeout_seconds=30)
-
-        if run.status == "succeeded":
+        if result["status"] == "succeeded":
             return {
                 "status": "success",
-                "output": run.output_json,
-                "run_id": str(run.id),
+                "output": result,
+                "run_id": result["run_id"],
             }
 
         return {
             "status": "error",
-            "error": run.error_text or "execution_failed",
-            "run_id": str(run.id),
+            "error": result["content"][0]["text"] if result.get("content") else "execution_failed",
+            "run_id": result.get("run_id"),
         }
     except Exception as e:
         # Don't leak internal details
+        error_text = str(e)
+        if "Agent mismatch" in error_text:
+            return {
+                "status": "error",
+                "error": "agent_session_mismatch",
+                "error_description": error_text,
+            }
+        if "not found" in error_text:
+            return {"status": "error", "error": "agent_not_found"}
+        if "Policy denied" in error_text:
+            return {
+                "status": "error",
+                "error": "policy_denied",
+                "error_description": error_text,
+            }
+
         logger.error(
             f"Error executing tool {tool.name} via AgentxSuite",
             extra={
                 "tool_id": str(tool.id),
-                "agent_id": str(agent.id),
+                "agent_id": token_agent_id or agent_id,
                 "error_type": type(e).__name__,
             },
             exc_info=True,

--- a/backend/mcp_fabric/jsonrpc.py
+++ b/backend/mcp_fabric/jsonrpc.py
@@ -1,0 +1,225 @@
+"""
+Shared JSON-RPC handling for AgentxSuite MCP transports.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from asgiref.sync import sync_to_async
+
+from apps.agents.models import Agent
+from apps.runs.services import ExecutionContext, execute_tool_run
+from apps.tenants.models import Environment, Organization
+from mcp_fabric.registry import get_tools_list_for_org_env
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_mcp_tool_name(name: str) -> str:
+    """Normalize tool names to the MCP-compatible pattern."""
+    normalized = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return normalized[:64] or "unnamed_tool"
+
+
+@dataclass
+class MCPJsonRpcContext:
+    """Tenant and token context resolved before handling JSON-RPC messages."""
+
+    organization: Organization
+    environment: Environment
+    token_claims: dict[str, Any]
+    agent: Agent | None = None
+    server_name: str = "agentxsuite"
+
+
+class MCPJsonRpcHandler:
+    """Handle MCP JSON-RPC methods independent of the transport."""
+
+    def __init__(self, context: MCPJsonRpcContext):
+        self.context = context
+        self.initialized = False
+
+    async def handle_message(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        """Route a single JSON-RPC request or notification."""
+        msg_id = message.get("id")
+        method = message.get("method")
+
+        if msg_id is None:
+            logger.debug("Received MCP notification: %s", method)
+            return None
+
+        try:
+            if method == "initialize":
+                return await self.handle_initialize(message)
+            if method == "tools/list":
+                return await self.handle_tools_list(message)
+            if method == "tools/call":
+                return await self.handle_tool_call(message)
+            if method == "resources/list":
+                return self._success_response(msg_id, {"resources": []})
+            if method == "prompts/list":
+                return self._success_response(msg_id, {"prompts": []})
+
+            return self._error_response(
+                msg_id,
+                -32601,
+                "Method not found",
+                f"Unknown method: {method}",
+            )
+        except Exception as exc:
+            logger.error("Error handling MCP method %s", method, exc_info=True)
+            return self._error_response(
+                msg_id,
+                -32603,
+                "Internal error",
+                str(exc),
+            )
+
+    async def handle_initialize(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Return server capabilities for MCP initialization."""
+        msg_id = message.get("id")
+        params = message.get("params", {})
+        protocol_version = params.get("protocolVersion", "2024-11-05")
+        self.initialized = True
+
+        return self._success_response(
+            msg_id,
+            {
+                "protocolVersion": protocol_version,
+                "capabilities": {
+                    "tools": {},
+                    "resources": {},
+                    "prompts": {},
+                },
+                "serverInfo": {
+                    "name": self.context.server_name,
+                    "version": "1.0.0",
+                },
+            },
+        )
+
+    async def handle_tools_list(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Return enabled tools for the resolved organization/environment."""
+        msg_id = message.get("id")
+        tools = await sync_to_async(get_tools_list_for_org_env)(
+            org=self.context.organization,
+            env=self.context.environment,
+        )
+
+        normalized_tools = []
+        for tool in tools:
+            original_name = tool.get("name", "")
+            normalized_tool = {**tool, "name": self._normalize_tool_name(original_name)}
+            if not normalized_tool.get("description"):
+                normalized_tool["description"] = f"Tool: {original_name}"
+            normalized_tools.append(normalized_tool)
+
+        return self._success_response(msg_id, {"tools": normalized_tools})
+
+    async def handle_tool_call(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Execute a tool using MCP params `{name, arguments}`."""
+        msg_id = message.get("id")
+        params = message.get("params") or {}
+        tool_name = params.get("name")
+        arguments = params.get("arguments") or {}
+
+        if not tool_name:
+            return self._error_response(
+                msg_id,
+                -32602,
+                "Invalid params",
+                "Missing 'name' parameter",
+            )
+
+        if not isinstance(arguments, dict):
+            return self._error_response(
+                msg_id,
+                -32602,
+                "Invalid params",
+                "'arguments' must be an object",
+            )
+
+        try:
+            result = await sync_to_async(execute_tool_run)(
+                organization=self.context.organization,
+                environment=self.context.environment,
+                tool_identifier=tool_name,
+                agent_identifier=None,
+                input_data=arguments,
+                context=ExecutionContext.from_token_claims(self.context.token_claims),
+            )
+        except ValueError as exc:
+            message_text = str(exc)
+            if "not found" in message_text.lower():
+                return self._error_response(msg_id, -32602, "Tool not found", message_text)
+
+            return self._success_response(
+                msg_id,
+                {
+                    "content": [{"type": "text", "text": message_text}],
+                    "isError": True,
+                },
+            )
+
+        return self._success_response(
+            msg_id,
+            {
+                "content": self._content_from_execution_result(result),
+                "isError": bool(result.get("isError")),
+            },
+        )
+
+    def _content_from_execution_result(self, result: dict[str, Any]) -> list[dict[str, str]]:
+        content = result.get("content")
+        if isinstance(content, list):
+            return content
+
+        if "output" in result:
+            return self._content_from_value(result["output"])
+        if "result" in result:
+            return self._content_from_value(result["result"])
+        if result:
+            return self._content_from_value(result)
+        return []
+
+    def _content_from_value(self, value: Any) -> list[dict[str, str]]:
+        if isinstance(value, str):
+            text = value
+        else:
+            text = json.dumps(value, indent=2)
+        return [{"type": "text", "text": text}]
+
+    def _normalize_tool_name(self, name: str) -> str:
+        return normalize_mcp_tool_name(name)
+
+    def _success_response(self, msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": result,
+        }
+
+    def _error_response(
+        self,
+        msg_id: Any,
+        code: int,
+        message: str,
+        data: Any = None,
+    ) -> dict[str, Any]:
+        error = {
+            "code": code,
+            "message": message,
+        }
+        if data is not None:
+            error["data"] = data
+
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": error,
+        }

--- a/backend/mcp_fabric/registry.py
+++ b/backend/mcp_fabric/registry.py
@@ -4,22 +4,43 @@ Registry for dynamically registering Django tools with fastmcp MCPServer.
 from __future__ import annotations
 
 import logging
-import types
 from typing import TYPE_CHECKING, Any
 
-from apps.tools.models import Tool
+from django.conf import settings
+
+from apps.tools.models import CuratedTool, Tool
 
 if TYPE_CHECKING:
     from fastmcp.server.server import FastMCP as MCPServer
+
     from apps.tenants.models import Environment, Organization
 
 logger = logging.getLogger(__name__)
 
 
+def _tool_curation_enabled() -> bool:
+    """Return whether curated tools should be exposed to MCP clients."""
+    return bool(getattr(settings, "TOOL_CURATION_ENABLED", False))
+
+
+def _agent_tool_mode() -> str:
+    """Return the configured agent-facing tool exposure mode."""
+    return getattr(settings, "AGENT_TOOL_MODE", "raw_only")
+
+
+def _tool_definition(name: str, description: str | None, input_schema: dict) -> dict:
+    """Build a MCP-compatible tool definition."""
+    return {
+        "name": name,
+        "description": description or f"Tool: {name}",
+        "inputSchema": input_schema or {"type": "object"},
+    }
+
+
 def get_tools_list_for_org_env(
     *,
-    org: "Organization",
-    env: "Environment",
+    org: Organization,
+    env: Environment,
 ) -> list[dict]:
     """
     Get list of available tools for organization/environment in MCP-compatible format.
@@ -44,21 +65,36 @@ def get_tools_list_for_org_env(
     """
     tools_list = []
     
-    # Get regular tools from database
-    tools = Tool.objects.filter(
-        organization=org, environment=env, enabled=True
-    ).select_related("connection")
-    
-    for tool in tools:
+    if _tool_curation_enabled() and _agent_tool_mode() != "raw_only":
+        curated_tools = CuratedTool.objects.filter(
+            organization=org,
+            environment=env,
+            enabled=True,
+        ).select_related("connection")
+
+        for tool in curated_tools:
+            tools_list.append(
+                _tool_definition(tool.name, tool.description, tool.schema_json)
+            )
+
+    if not _tool_curation_enabled() or _agent_tool_mode() == "raw_only":
+        raw_tools = Tool.objects.filter(
+            organization=org, environment=env, enabled=True
+        ).select_related("connection")
+    elif _agent_tool_mode() == "curated_and_raw":
+        raw_tools = Tool.objects.filter(
+            organization=org,
+            environment=env,
+            enabled=True,
+            is_agent_visible=True,
+        ).select_related("connection")
+    else:
+        raw_tools = Tool.objects.none()
+
+    for tool in raw_tools:
         input_schema = getattr(tool, "schema_json", None) or {"type": "object"}
         description = input_schema.get("description") if isinstance(input_schema, dict) else None
-        
-        tool_dict = {
-            "name": tool.name,
-            "description": description or f"Tool: {tool.name}",
-            "inputSchema": input_schema,
-        }
-        tools_list.append(tool_dict)
+        tools_list.append(_tool_definition(tool.name, description, input_schema))
     
     # Add system tools
     from apps.system_tools.tools import SYSTEM_TOOLS
@@ -75,10 +111,10 @@ def get_tools_list_for_org_env(
 
 
 def register_tools_for_org_env(
-    mcp: "MCPServer",
+    mcp: MCPServer,
     *,
-    org: "Organization",
-    env: "Environment",
+    org: Organization,
+    env: Environment,
 ) -> None:
     """
     Register all enabled tools for an organization/environment with fastmcp.
@@ -92,22 +128,21 @@ def register_tools_for_org_env(
         org: Organization instance
         env: Environment instance
     """
-    # Register regular tools
-    tools = Tool.objects.filter(
-        organization=org, environment=env, enabled=True
-    ).select_related("connection")
+    tools = _get_agent_executable_tools(org=org, env=env)
 
     for tool in tools:
         input_schema = getattr(tool, "schema_json", None) or {"type": "object"}
         description = input_schema.get("description") if isinstance(input_schema, dict) else None
-        version = getattr(tool, "version", None) or "1.0.0"
 
         # FastMCP doesn't support **kwargs, so we need to create a function
         # with explicit parameters matching the schema
         # We'll create a function that accepts all schema properties as optional parameters
-        schema_props = input_schema.get("properties", {}) if isinstance(input_schema, dict) else {}
-        
-        def create_handler(_t: Tool = tool, _schema: dict = input_schema):
+
+        def create_handler(
+            _t: Tool | CuratedTool = tool,
+            _schema: dict = input_schema,
+            _description: str | None = description,
+        ):
             # Create function code dynamically based on schema properties
             param_names = list(_schema.get("properties", {}).keys()) if isinstance(_schema, dict) else []
             
@@ -129,22 +164,22 @@ def register_tools_for_org_env(
                     "jti = payload.pop('_jti', None)",
                     "client_ip = payload.pop('_client_ip', None)",
                     "request_id = payload.pop('_request_id', None)",
-                    "from mcp_fabric.adapters import run_tool_via_agentxsuite",
-                    "return run_tool_via_agentxsuite(tool=_t, payload=payload, agent_id=agent_id, token_agent_id=token_agent_id, jti=jti, client_ip=client_ip, request_id=request_id)",
+                    "from apps.runs.services import ExecutionContext, execute_tool_run",
+                    "return execute_tool_run(organization=_t.organization, environment=_t.environment, tool_identifier=str(_t.id), agent_identifier=agent_id, input_data=payload, context=ExecutionContext(token_agent_id=token_agent_id, jti=jti, client_ip=client_ip, request_id=request_id))",
                 ])
                 # Join with proper indentation (4 spaces)
                 body_str = "\n    ".join(body_lines)
                 func_code = f"def _handler({params_str}) -> dict:\n    {body_str}"
             else:
                 # No parameters - empty function
-                func_code = "def _handler() -> dict:\n    payload = {}\n    agent_id = payload.pop('agent_id', None)\n    token_agent_id = payload.pop('_token_agent_id', None)\n    jti = payload.pop('_jti', None)\n    client_ip = payload.pop('_client_ip', None)\n    request_id = payload.pop('_request_id', None)\n    from mcp_fabric.adapters import run_tool_via_agentxsuite\n    return run_tool_via_agentxsuite(tool=_t, payload=payload, agent_id=agent_id, token_agent_id=token_agent_id, jti=jti, client_ip=client_ip, request_id=request_id)"
+                func_code = "def _handler() -> dict:\n    payload = {}\n    agent_id = payload.pop('agent_id', None)\n    token_agent_id = payload.pop('_token_agent_id', None)\n    jti = payload.pop('_jti', None)\n    client_ip = payload.pop('_client_ip', None)\n    request_id = payload.pop('_request_id', None)\n    from apps.runs.services import ExecutionContext, execute_tool_run\n    return execute_tool_run(organization=_t.organization, environment=_t.environment, tool_identifier=str(_t.id), agent_identifier=agent_id, input_data=payload, context=ExecutionContext(token_agent_id=token_agent_id, jti=jti, client_ip=client_ip, request_id=request_id))"
             
             # Execute function code in local namespace
             namespace = {"_t": _t, "Any": Any}
             exec(func_code, namespace)
             handler = namespace["_handler"]
             handler.__name__ = _t.name
-            handler.__doc__ = description or f"Tool: {_t.name}"
+            handler.__doc__ = _description or f"Tool: {_t.name}"
             return handler
 
         try:
@@ -153,7 +188,7 @@ def register_tools_for_org_env(
             
             # Register tool - FastMCP will infer parameters from function signature
             # and use the schema properties for validation
-            registered_tool = mcp.tool(
+            mcp.tool(
                 name=tool.name,
                 description=description or f"Tool: {tool.name}",
             )(handler)
@@ -181,10 +216,10 @@ def register_tools_for_org_env(
 
 
 def register_system_tools_for_org_env(
-    mcp: "MCPServer",
+    mcp: MCPServer,
     *,
-    org: "Organization",
-    env: "Environment",
+    org: Organization,
+    env: Environment,
 ) -> None:
     """
     Register system tools for an organization/environment.
@@ -196,8 +231,8 @@ def register_system_tools_for_org_env(
         org: Organization instance
         env: Environment instance
     """
-    from apps.system_tools.tools import SYSTEM_TOOLS
     from apps.system_tools.services import TOOL_HANDLERS
+    from apps.system_tools.tools import SYSTEM_TOOLS
     
     for tool_def in SYSTEM_TOOLS:
         tool_name = tool_def["name"]
@@ -222,12 +257,14 @@ def register_system_tools_for_org_env(
             _handler=handler_func,
             _org=org,
             _env=env,
+            _param_names=param_names,
+            _tool_name=tool_name,
         ):
             # Build parameter string including metadata params (will be filtered out)
-            all_params = param_names + ["_token_agent_id", "_jti", "_client_ip", "_request_id"]
+            all_params = _param_names + ["_token_agent_id", "_jti", "_client_ip", "_request_id"]
             params_str = ", ".join([f"{name}: Any = None" for name in all_params])
             
-            if param_names:
+            if _param_names:
                 body_lines = [
                     "payload = {}",
                     "# Extract metadata params from function parameters",
@@ -237,23 +274,23 @@ def register_system_tools_for_org_env(
                     "request_id = _request_id if '_request_id' in locals() else None",
                 ]
                 # Only add schema-defined parameters to payload
-                for name in param_names:
+                for name in _param_names:
                     body_lines.append(f"if {name} is not None: payload['{name}'] = {name}")
                 body_lines.extend([
                     f"payload['organization_id'] = '{_org.id}'",
                     f"payload['environment_id'] = '{_env.id}'",
-                    f"from apps.system_tools.services import run_system_tool_with_audit, TOOL_HANDLERS",
-                    f"return run_system_tool_with_audit(",
-                    f"    tool_name='{tool_name}',",
-                    f"    handler=TOOL_HANDLERS['{tool_name}'],",
-                    f"    payload=payload,",
+                    "from apps.system_tools.services import run_system_tool_with_audit, TOOL_HANDLERS",
+                    "return run_system_tool_with_audit(",
+                    f"    tool_name='{_tool_name}',",
+                    f"    handler=TOOL_HANDLERS['{_tool_name}'],",
+                    "    payload=payload,",
                     f"    organization_id='{_org.id}',",
                     f"    environment_id='{_env.id}',",
-                    f"    token_agent_id=token_agent_id,",
-                    f"    jti=jti,",
-                    f"    client_ip=client_ip,",
-                    f"    request_id=request_id,",
-                    f")",
+                    "    token_agent_id=token_agent_id,",
+                    "    jti=jti,",
+                    "    client_ip=client_ip,",
+                    "    request_id=request_id,",
+                    ")",
                 ])
                 body_str = "\n    ".join(body_lines)
                 func_code = f"def _system_handler({params_str}) -> dict:\n    {body_str}"
@@ -265,8 +302,8 @@ def register_system_tools_for_org_env(
     payload['environment_id'] = '{_env.id}'
     from apps.system_tools.services import run_system_tool_with_audit, TOOL_HANDLERS
     return run_system_tool_with_audit(
-        tool_name='{tool_name}',
-        handler=TOOL_HANDLERS['{tool_name}'],
+        tool_name='{_tool_name}',
+        handler=TOOL_HANDLERS['{_tool_name}'],
         payload=payload,
         organization_id='{_org.id}',
         environment_id='{_env.id}',
@@ -285,7 +322,7 @@ def register_system_tools_for_org_env(
         
         try:
             handler = create_system_handler()
-            registered_tool = mcp.tool(
+            mcp.tool(
                 name=tool_name,
                 description=tool_def["description"],
             )(handler)
@@ -308,3 +345,38 @@ def register_system_tools_for_org_env(
                 exc_info=True,
             )
 
+
+def _get_agent_executable_tools(*, org: Organization, env: Environment):
+    """Return raw and/or curated tool objects that should be registered for agents."""
+    if _tool_curation_enabled() and _agent_tool_mode() != "raw_only":
+        curated_tools = list(
+            CuratedTool.objects.filter(
+                organization=org,
+                environment=env,
+                enabled=True,
+            ).select_related("connection")
+        )
+    else:
+        curated_tools = []
+
+    if not _tool_curation_enabled() or _agent_tool_mode() == "raw_only":
+        raw_tools = list(
+            Tool.objects.filter(
+                organization=org,
+                environment=env,
+                enabled=True,
+            ).select_related("connection")
+        )
+    elif _agent_tool_mode() == "curated_and_raw":
+        raw_tools = list(
+            Tool.objects.filter(
+                organization=org,
+                environment=env,
+                enabled=True,
+                is_agent_visible=True,
+            ).select_related("connection")
+        )
+    else:
+        raw_tools = []
+
+    return [*curated_tools, *raw_tools]

--- a/backend/mcp_fabric/settings.py
+++ b/backend/mcp_fabric/settings.py
@@ -40,6 +40,7 @@ AUTHORIZATION_SERVERS = config(
 
 # Supported scopes for MCP Fabric
 SCOPES_SUPPORTED = [
+    "mcp:connect",  # Establish Streamable HTTP/SSE sessions
     "mcp:manifest",  # Access to manifest endpoint
     "mcp:tools",  # Access to tools listing
     "mcp:run",  # Access to tool execution

--- a/backend/mcp_fabric/stdio_adapter.py
+++ b/backend/mcp_fabric/stdio_adapter.py
@@ -31,10 +31,8 @@ from asgiref.sync import sync_to_async
 
 from apps.agents.models import Agent
 from apps.tenants.models import Environment, Organization
-from mcp_fabric.adapters import run_tool_via_agentxsuite
 from mcp_fabric.deps import get_validated_token
-from mcp_fabric.errors import ErrorCodes
-from mcp_fabric.registry import get_tools_list_for_org_env
+from mcp_fabric.jsonrpc import MCPJsonRpcContext, MCPJsonRpcHandler, normalize_mcp_tool_name
 
 # Configure logging to stderr only
 logging.basicConfig(
@@ -65,6 +63,7 @@ class StdioMCPAdapter:
         self.env: Environment | None = None
         self.agent: Agent | None = None
         self.token_claims: dict[str, Any] | None = None
+        self.handler: MCPJsonRpcHandler | None = None
         self.initialized = False
 
     async def start(self):
@@ -165,14 +164,41 @@ class StdioMCPAdapter:
                     logger.warning(f"Agent {agent_id} not found, will auto-select")
             
             logger.info(f"Validated token for org={self.org.name}, env={self.env.name}")
+            self.handler = self._build_handler()
             
         except Exception as e:
             logger.error(f"Token validation failed: {e}")
             raise
 
+    def _build_handler(self) -> MCPJsonRpcHandler:
+        """Build the shared JSON-RPC handler for this stdio session."""
+        if not self.org or not self.env or self.token_claims is None:
+            raise ValueError("Organization/Environment not set")
+
+        resolved_agent_id = str(self.agent.id) if self.agent else self.token_claims.get("agent_id")
+        self.token_claims["_resolved_agent_id"] = resolved_agent_id
+        self.token_claims["_client_ip"] = None
+        self.token_claims["_jti"] = self.token_claims.get("_jti") or self.token_claims.get("jti")
+
+        return MCPJsonRpcHandler(
+            MCPJsonRpcContext(
+                organization=self.org,
+                environment=self.env,
+                agent=self.agent,
+                token_claims=self.token_claims,
+                server_name="agentxsuite",
+            )
+        )
+
+    def _get_handler(self) -> MCPJsonRpcHandler:
+        """Return the shared JSON-RPC handler, creating it for test-initialized adapters."""
+        if self.handler is None:
+            self.handler = self._build_handler()
+        return self.handler
+
     async def handle_message(self, message: dict) -> dict | None:
         """
-        Route JSON-RPC message to appropriate handler.
+        Route JSON-RPC message to the shared transport-independent handler.
         
         Args:
             message: JSON-RPC message
@@ -180,214 +206,35 @@ class StdioMCPAdapter:
         Returns:
             JSON-RPC response or None (for notifications)
         """
-        # Check if this is a notification (no id field)
-        is_notification = message.get("id") is None
-        
-        if is_notification:
-            logger.debug(f"Received notification: {message.get('method')}")
-            # Notifications don't require responses
-            return None
-        
-        method = message.get("method")
-        msg_id = message.get("id")
-        
-        try:
-            if method == "initialize":
-                return await self.handle_initialize(message)
-            elif method == "tools/list":
-                return await self.handle_tools_list(message)
-            elif method == "tools/call":
-                return await self.handle_tool_call(message)
-            elif method == "resources/list":
-                return await self.handle_resources_list(message)
-            elif method == "prompts/list":
-                return await self.handle_prompts_list(message)
-            else:
-                return self._error_response(
-                    msg_id,
-                    -32601,
-                    "Method not found",
-                    f"Unknown method: {method}",
-                )
-        except Exception as e:
-            logger.error(f"Error handling {method}: {e}", exc_info=True)
-            return self._error_response(
-                msg_id,
-                -32603,
-                "Internal error",
-                str(e),
-            )
+        response = await self._get_handler().handle_message(message)
+        self.initialized = self._get_handler().initialized
+        return response
 
     async def handle_initialize(self, message: dict) -> dict:
         """
-        Handle MCP initialize request.
+        Handle MCP initialize request via the shared JSON-RPC handler.
         
         Returns server capabilities and protocol version.
         """
-        msg_id = message.get("id")
-        params = message.get("params", {})
-        client_protocol_version = params.get("protocolVersion", "2024-11-05")
-        
-        self.initialized = True
-        
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {
-                "protocolVersion": client_protocol_version,
-                "capabilities": {
-                    "tools": {},  # We support tools
-                    "resources": {},  # We support resources
-                    "prompts": {},  # We support prompts
-                },
-                "serverInfo": {
-                    "name": "agentxsuite",
-                    "version": "1.0.0",
-                },
-            },
-        }
+        response = await self._get_handler().handle_initialize(message)
+        self.initialized = self._get_handler().initialized
+        return response
 
     async def handle_tools_list(self, message: dict) -> dict:
         """
-        Handle tools/list request.
+        Handle tools/list request via the shared JSON-RPC handler.
         
         Returns all enabled tools for the org/env.
         """
-        msg_id = message.get("id")
-        
-        if not self.org or not self.env:
-            return self._error_response(
-                msg_id,
-                -32603,
-                "Not initialized",
-                "Organization/Environment not set",
-            )
-        
-        try:
-            # Get tools from registry
-            tools = await sync_to_async(get_tools_list_for_org_env)(
-                org=self.org,
-                env=self.env,
-            )
-            
-            # Normalize tool names for MCP spec (^[a-zA-Z0-9_-]{1,64}$)
-            normalized_tools = []
-            for tool in tools:
-                original_name = tool.get("name", "")
-                normalized_name = self._normalize_tool_name(original_name)
-                
-                normalized_tool = {**tool, "name": normalized_name}
-                
-                # Ensure description exists
-                if "description" not in normalized_tool or not normalized_tool["description"]:
-                    normalized_tool["description"] = f"Tool: {original_name}"
-                
-                normalized_tools.append(normalized_tool)
-            
-            return {
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {
-                    "tools": normalized_tools,
-                },
-            }
-            
-        except Exception as e:
-            logger.error(f"Error listing tools: {e}", exc_info=True)
-            return self._error_response(
-                msg_id,
-                -32603,
-                "Internal error",
-                str(e),
-            )
+        return await self._get_handler().handle_tools_list(message)
 
     async def handle_tool_call(self, message: dict) -> dict:
         """
-        Handle tools/call request.
+        Handle tools/call request via the shared JSON-RPC handler.
         
         Executes a tool via AgentxSuite's run service with full security pipeline.
         """
-        msg_id = message.get("id")
-        params = message.get("params", {})
-        tool_name = params.get("name")
-        arguments = params.get("arguments", {})
-        
-        if not tool_name:
-            return self._error_response(
-                msg_id,
-                -32602,
-                "Invalid params",
-                "Missing 'name' parameter",
-            )
-        
-        try:
-            # Find tool by name
-            from apps.tools.models import Tool
-            
-            tool = await sync_to_async(
-                Tool.objects.filter(
-                    organization=self.org,
-                    environment=self.env,
-                    name=tool_name,
-                    enabled=True,
-                ).first
-            )()
-            
-            if not tool:
-                return self._error_response(
-                    msg_id,
-                    -32602,
-                    "Tool not found",
-                    f"Tool '{tool_name}' not found or not enabled",
-                )
-            
-            # Execute tool via AgentxSuite adapter
-            result = await sync_to_async(run_tool_via_agentxsuite)(
-                tool=tool,
-                payload=arguments,
-                agent_id=self.agent.id if self.agent else None,
-                token_agent_id=self.agent.id if self.agent else None,
-                jti=self.token_claims.get("jti"),
-                client_ip=None,  # Not available in stdio context
-                request_id=str(msg_id),
-            )
-            
-            # Convert result to MCP format
-            if result.get("status") == "success":
-                output = result.get("output", {})
-                # MCP expects content array
-                content = [{"type": "text", "text": json.dumps(output, indent=2)}]
-                
-                return {
-                    "jsonrpc": "2.0",
-                    "id": msg_id,
-                    "result": {
-                        "content": content,
-                        "isError": False,
-                    },
-                }
-            else:
-                error_msg = result.get("error", "Unknown error")
-                error_desc = result.get("error_description", error_msg)
-                content = [{"type": "text", "text": error_desc}]
-                
-                return {
-                    "jsonrpc": "2.0",
-                    "id": msg_id,
-                    "result": {
-                        "content": content,
-                        "isError": True,
-                    },
-                }
-                
-        except Exception as e:
-            logger.error(f"Error executing tool {tool_name}: {e}", exc_info=True)
-            return self._error_response(
-                msg_id,
-                -32603,
-                "Tool execution error",
-                str(e),
-            )
+        return await self._get_handler().handle_tool_call(message)
 
     async def handle_resources_list(self, message: dict) -> dict:
         """
@@ -395,15 +242,7 @@ class StdioMCPAdapter:
         
         Returns empty list for now (Phase 3).
         """
-        msg_id = message.get("id")
-        
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {
-                "resources": [],
-            },
-        }
+        return self._get_handler()._success_response(message.get("id"), {"resources": []})
 
     async def handle_prompts_list(self, message: dict) -> dict:
         """
@@ -411,15 +250,7 @@ class StdioMCPAdapter:
         
         Returns empty list for now (Phase 3).
         """
-        msg_id = message.get("id")
-        
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {
-                "prompts": [],
-            },
-        }
+        return self._get_handler()._success_response(message.get("id"), {"prompts": []})
 
     def _normalize_tool_name(self, name: str) -> str:
         """
@@ -431,18 +262,7 @@ class StdioMCPAdapter:
         Returns:
             Normalized tool name
         """
-        import re
-        
-        # Replace invalid characters with underscore
-        normalized = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
-        # Collapse multiple underscores
-        normalized = re.sub(r"_+", "_", normalized)
-        # Remove leading/trailing underscores
-        normalized = normalized.strip("_")
-        # Limit to 64 characters
-        normalized = normalized[:64]
-        
-        return normalized or "unnamed_tool"
+        return normalize_mcp_tool_name(name)
 
     def _write_response(self, response: dict):
         """
@@ -478,18 +298,7 @@ class StdioMCPAdapter:
         Returns:
             JSON-RPC error response
         """
-        error = {
-            "code": code,
-            "message": message,
-        }
-        if data is not None:
-            error["data"] = data
-        
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "error": error,
-        }
+        return self._get_handler()._error_response(msg_id, code, message, data)
 
 
 async def main():

--- a/backend/mcp_fabric/tests/test_curation_registry.py
+++ b/backend/mcp_fabric/tests/test_curation_registry.py
@@ -1,0 +1,92 @@
+"""Tests for curated tool exposure through the MCP registry."""
+from __future__ import annotations
+
+import pytest
+from django.test import override_settings
+from model_bakery import baker
+
+from apps.connections.models import Connection
+from apps.tenants.models import Environment, Organization
+from apps.tools.models import CuratedTool, Tool
+from mcp_fabric.registry import get_tools_list_for_org_env
+
+
+@pytest.mark.django_db
+@override_settings(TOOL_CURATION_ENABLED=True, AGENT_TOOL_MODE="curated_only")
+def test_registry_lists_curated_tools_when_curation_enabled():
+    """Agent-facing MCP lists use CuratedTool when curation is enabled."""
+    org = baker.make(Organization, name="TestOrg")
+    env = baker.make(Environment, organization=org, name="dev", type="dev")
+    conn = baker.make(Connection, organization=org, environment=env, name="remote")
+    baker.make(
+        Tool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="raw_search",
+        enabled=True,
+        is_agent_visible=True,
+    )
+    baker.make(
+        CuratedTool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="search_docs",
+        display_name="Search Docs",
+        description="Search curated docs.",
+        schema_json={"type": "object", "properties": {"query": {"type": "string"}}},
+        curator_type="passthrough",
+        enabled=True,
+    )
+
+    tools = get_tools_list_for_org_env(org=org, env=env)
+    tool_names = {tool["name"] for tool in tools}
+
+    assert "search_docs" in tool_names
+    assert "raw_search" not in tool_names
+
+
+@pytest.mark.django_db
+@override_settings(TOOL_CURATION_ENABLED=True, AGENT_TOOL_MODE="curated_and_raw")
+def test_registry_lists_curated_and_agent_visible_raw_tools():
+    """Power users can expose selected raw tools alongside curated tools."""
+    org = baker.make(Organization, name="TestOrg")
+    env = baker.make(Environment, organization=org, name="dev", type="dev")
+    conn = baker.make(Connection, organization=org, environment=env, name="remote")
+    baker.make(
+        Tool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="visible_raw",
+        enabled=True,
+        is_agent_visible=True,
+    )
+    baker.make(
+        Tool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="hidden_raw",
+        enabled=True,
+        is_agent_visible=False,
+    )
+    baker.make(
+        CuratedTool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="curated_search",
+        display_name="Curated Search",
+        curator_type="passthrough",
+        enabled=True,
+    )
+
+    tools = get_tools_list_for_org_env(org=org, env=env)
+    tool_names = {tool["name"] for tool in tools}
+
+    assert "curated_search" in tool_names
+    assert "visible_raw" in tool_names
+    assert "hidden_raw" not in tool_names
+

--- a/backend/mcp_fabric/tests/test_jsonrpc_handler.py
+++ b/backend/mcp_fabric/tests/test_jsonrpc_handler.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import mcp_fabric.jsonrpc as jsonrpc_module
+from mcp_fabric.jsonrpc import MCPJsonRpcContext, MCPJsonRpcHandler
+
+
+async def _call_sync(func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+def _sync_to_async(func):
+    async def wrapper(*args, **kwargs):
+        return await _call_sync(func, *args, **kwargs)
+
+    return wrapper
+
+
+def test_tools_call_maps_mcp_name_arguments_to_execution_service(monkeypatch):
+    org = SimpleNamespace(id="org-id", name="Org")
+    env = SimpleNamespace(id="env-id", name="Env")
+    claims = {"_resolved_agent_id": "agent-id", "jti": "jti-1"}
+    handler = MCPJsonRpcHandler(
+        MCPJsonRpcContext(organization=org, environment=env, token_claims=claims)
+    )
+    execute_tool_run = Mock(
+        return_value={
+            "content": [{"type": "text", "text": "ok"}],
+            "isError": False,
+        },
+    )
+    monkeypatch.setattr(jsonrpc_module, "execute_tool_run", execute_tool_run)
+    monkeypatch.setattr(jsonrpc_module, "sync_to_async", lambda f: _sync_to_async(f))
+
+    response = asyncio.run(
+        handler.handle_tool_call(
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "mcp"},
+                },
+            }
+        )
+    )
+
+    assert response["result"]["isError"] is False
+    execute_tool_run.assert_called_once()
+    call_kwargs = execute_tool_run.call_args.kwargs
+    assert call_kwargs["organization"] == org
+    assert call_kwargs["environment"] == env
+    assert call_kwargs["tool_identifier"] == "search_docs"
+    assert call_kwargs["agent_identifier"] is None
+    assert call_kwargs["input_data"] == {"query": "mcp"}
+
+
+def test_tools_call_rejects_non_object_arguments():
+    handler = MCPJsonRpcHandler(
+        MCPJsonRpcContext(
+            organization=SimpleNamespace(),
+            environment=SimpleNamespace(),
+            token_claims={},
+        )
+    )
+
+    response = asyncio.run(
+        handler.handle_tool_call(
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {"name": "search_docs", "arguments": "bad"},
+            }
+        )
+    )
+
+    assert response["error"]["code"] == -32602
+    assert "'arguments' must be an object" in response["error"]["data"]

--- a/backend/mcp_fabric/tests/test_stdio_adapter.py
+++ b/backend/mcp_fabric/tests/test_stdio_adapter.py
@@ -3,12 +3,11 @@ Tests for stdio MCP Adapter.
 """
 from __future__ import annotations
 
-import asyncio
-import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
+import mcp_fabric.jsonrpc as jsonrpc_module
 from apps.agents.models import Agent
 from apps.tenants.models import Environment, Organization
 from apps.tools.models import Tool
@@ -175,7 +174,7 @@ class TestStdioMCPAdapter:
             }
         ]
         
-        with patch("mcp_fabric.stdio_adapter.get_tools_list_for_org_env", return_value=mock_tools):
+        with patch("mcp_fabric.jsonrpc.get_tools_list_for_org_env", return_value=mock_tools):
             response = await adapter.handle_tools_list(message)
         
         assert response["jsonrpc"] == "2.0"
@@ -209,17 +208,11 @@ class TestStdioMCPAdapter:
         
         # Mock tool lookup and execution to avoid DB locks
         mock_result = {
-            "status": "success",
             "output": {"result": "test output"},
             "run_id": "test-run-id",
         }
-        
-        # Mock Tool.objects.filter().first() chain
-        mock_queryset = MagicMock()
-        mock_queryset.first = MagicMock(return_value=tool)
-        
-        with patch("apps.tools.models.Tool.objects.filter", return_value=mock_queryset), \
-             patch("mcp_fabric.stdio_adapter.run_tool_via_agentxsuite", return_value=mock_result):
+
+        with patch.object(jsonrpc_module, "execute_tool_run", return_value=mock_result):
             response = await adapter.handle_tool_call(message)
         
         assert response["jsonrpc"] == "2.0"
@@ -277,17 +270,11 @@ class TestStdioMCPAdapter:
         
         # Mock tool lookup and execution failure to avoid DB locks
         mock_result = {
-            "status": "error",
-            "error": "tool_execution_failed",
-            "error_description": "Tool execution failed for some reason",
+            "content": [{"type": "text", "text": "Tool execution failed for some reason"}],
+            "isError": True,
         }
-        
-        # Mock Tool.objects.filter().first() chain
-        mock_queryset = MagicMock()
-        mock_queryset.first = MagicMock(return_value=tool)
-        
-        with patch("apps.tools.models.Tool.objects.filter", return_value=mock_queryset), \
-             patch("mcp_fabric.stdio_adapter.run_tool_via_agentxsuite", return_value=mock_result):
+
+        with patch.object(jsonrpc_module, "execute_tool_run", return_value=mock_result):
             response = await adapter.handle_tool_call(message)
         
         assert response["jsonrpc"] == "2.0"

--- a/backend/mcp_gateway/Dockerfile
+++ b/backend/mcp_gateway/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy gateway code
+COPY __init__.py .
+COPY main.py .
+
+# Expose port
+EXPOSE 8091
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD python -c "import httpx; httpx.get('http://localhost:8091/health')"
+
+# Run gateway
+CMD ["python", "main.py"]
+

--- a/backend/mcp_gateway/README.md
+++ b/backend/mcp_gateway/README.md
@@ -1,0 +1,182 @@
+# MCP Gateway Service
+
+A server-side bridge that translates SSE/WebSocket connections from MCP clients (like Claude Desktop) to HTTP requests to the internal FastMCP server.
+
+## Architecture
+
+```
+Claude Desktop → SSE/WebSocket → MCP Gateway → HTTP → FastMCP Server
+   (User)         (Port 8091)      (This)      (Port 8090)
+```
+
+## Benefits
+
+- ✅ **No local bridge needed** - Users don't install anything
+- ✅ **Centralized** - All translation happens on your server
+- ✅ **Secure** - Token validation on server-side
+- ✅ **Scalable** - Can handle multiple concurrent connections
+
+## How it Works
+
+1. **Client connects** via SSE or WebSocket to `https://mcp.agentxsuite.com`
+2. **Gateway receives** MCP protocol messages (JSON-RPC)
+3. **Gateway translates** to HTTP calls to internal FastMCP server
+4. **Gateway returns** responses back to client
+
+## User Configuration
+
+Users only need to configure Claude Desktop once:
+
+```json
+{
+  "mcpServers": {
+    "agentxsuite": {
+      "url": "https://mcp.agentxsuite.com/.well-known/mcp/sse",
+      "transport": "sse",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+## Running
+
+### Development
+
+```bash
+cd backend
+python mcp_gateway/main.py
+```
+
+Service runs on http://localhost:8091
+
+### Production
+
+```bash
+# With systemd
+sudo systemctl start mcp-gateway
+
+# With Docker
+docker run -p 8091:8091 agentxsuite-mcp-gateway
+
+# Behind Nginx
+# Configure nginx to proxy https://mcp.agentxsuite.com to localhost:8091
+```
+
+## Endpoints
+
+- `GET /.well-known/mcp` - Discovery endpoint
+- `GET /.well-known/mcp/sse` - SSE transport endpoint
+- `WS /.well-known/mcp/ws` - WebSocket transport endpoint
+- `GET /health` - Health check
+
+## Dependencies
+
+```
+fastapi
+uvicorn[standard]
+httpx
+sse-starlette
+```
+
+## Configuration
+
+Environment variables:
+
+- `FASTMCP_BACKEND_URL` - Internal FastMCP server URL (default: http://localhost:8090)
+- `PORT` - Gateway port (default: 8091)
+- `LOG_LEVEL` - Logging level (default: info)
+
+## Security
+
+- All tokens are validated by the backend FastMCP server
+- Gateway only proxies requests, doesn't store credentials
+- HTTPS required in production
+- CORS configured to allow only your domains
+
+## Testing
+
+```bash
+# Test SSE endpoint
+curl -N -H "Authorization: Bearer TOKEN" \
+  http://localhost:8091/.well-known/mcp/sse
+
+# Test WebSocket
+wscat -c ws://localhost:8091/.well-known/mcp/ws \
+  -H "Authorization: Bearer TOKEN"
+```
+
+## Deployment
+
+### Nginx Configuration
+
+```nginx
+upstream mcp_gateway {
+    server localhost:8091;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name mcp.agentxsuite.com;
+
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    location /.well-known/mcp/sse {
+        proxy_pass http://mcp_gateway;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        chunked_transfer_encoding off;
+        proxy_buffering off;
+        proxy_cache off;
+    }
+
+    location /.well-known/mcp/ws {
+        proxy_pass http://mcp_gateway;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
+    location / {
+        proxy_pass http://mcp_gateway;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+### Systemd Service
+
+```ini
+[Unit]
+Description=AgentxSuite MCP Gateway
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/agentxsuite/backend
+Environment="PATH=/opt/agentxsuite/venv/bin"
+ExecStart=/opt/agentxsuite/venv/bin/python mcp_gateway/main.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Monitoring
+
+Gateway logs all requests with:
+- Request ID
+- Client IP
+- Response time
+- Error rates
+
+Use these logs for monitoring and debugging.
+

--- a/backend/mcp_gateway/__init__.py
+++ b/backend/mcp_gateway/__init__.py
@@ -1,0 +1,10 @@
+"""
+MCP Gateway - SSE/WebSocket to HTTP bridge for Claude Desktop.
+
+This module provides a gateway that accepts SSE/WebSocket connections
+from MCP clients (like Claude Desktop) and proxies them to the internal
+HTTP-based FastMCP server.
+
+This eliminates the need for users to run a local bridge.
+"""
+

--- a/backend/mcp_gateway/docker-compose.yml
+++ b/backend/mcp_gateway/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  mcp-gateway:
+    build: .
+    ports:
+      - "8091:8091"
+    environment:
+      - FASTMCP_BACKEND_URL=http://mcp-fabric:8090
+      - LOG_LEVEL=info
+    depends_on:
+      - mcp-fabric
+    networks:
+      - agentxsuite
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8091/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  mcp-fabric:
+    image: agentxsuite-mcp-fabric:latest
+    ports:
+      - "8090:8090"
+    networks:
+      - agentxsuite
+
+networks:
+  agentxsuite:
+    driver: bridge
+

--- a/backend/mcp_gateway/main.py
+++ b/backend/mcp_gateway/main.py
@@ -1,0 +1,352 @@
+"""MCP Gateway Service - Streamable HTTP entrypoint for MCP clients."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from typing import Any
+
+import django
+from asgiref.sync import sync_to_async
+from django.conf import settings
+from django.core.cache import cache
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect, status
+from fastapi.responses import JSONResponse, Response
+from sse_starlette.sse import EventSourceResponse
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.dev")
+django.setup()
+
+from mcp_fabric.agent_resolver import resolve_agent_from_token_claims
+from mcp_fabric.deps import get_validated_token, get_www_authenticate_header
+from mcp_fabric.errors import ErrorCodes, raise_mcp_http_exception
+from mcp_fabric.jsonrpc import MCPJsonRpcContext, MCPJsonRpcHandler
+from mcp_fabric.settings import MCP_CANONICAL_URI
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_STATE_CACHE_PREFIX = "mcp_gateway:session:"
+GATEWAY_STATE_TIMEOUT_SECONDS = getattr(settings, "MCP_GATEWAY_STATE_TIMEOUT_SECONDS", 3600)
+
+app = FastAPI(
+    title="AgentxSuite MCP Gateway",
+    description="Streamable HTTP MCP gateway for AgentxSuite",
+    version="1.0.0",
+)
+
+
+def _extract_bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise raise_mcp_http_exception(
+            ErrorCodes.MISSING_TOKEN,
+            "Missing Authorization header",
+            status.HTTP_401_UNAUTHORIZED,
+            headers=get_www_authenticate_header(),
+        )
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise raise_mcp_http_exception(
+            ErrorCodes.INVALID_TOKEN,
+            "Authorization header must use Bearer token",
+            status.HTTP_401_UNAUTHORIZED,
+            headers=get_www_authenticate_header(),
+        )
+
+    return token
+
+
+async def _validated_claims_from_request(request: Request) -> dict[str, Any]:
+    """Validate bearer token and attach resolved agent/audit metadata."""
+    token = _extract_bearer_token(request.headers.get("authorization"))
+    resource = request.query_params.get("resource") or MCP_CANONICAL_URI
+    claims = get_validated_token(token, required_scopes=["mcp:connect"], resource=resource)
+
+    org_id = claims.get("org_id")
+    env_id = claims.get("env_id")
+    if not org_id or not env_id:
+        raise raise_mcp_http_exception(
+            ErrorCodes.AGENT_NOT_FOUND,
+            "Token missing org_id or env_id claims",
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    resolved_agent = await sync_to_async(resolve_agent_from_token_claims)(
+        claims,
+        str(org_id),
+        str(env_id),
+    )
+    if not resolved_agent:
+        raise raise_mcp_http_exception(
+            ErrorCodes.AGENT_NOT_FOUND,
+            "Agent not found or access denied",
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    query_agent_id = request.query_params.get("agent_id")
+    if query_agent_id and query_agent_id != str(resolved_agent.id):
+        raise raise_mcp_http_exception(
+            ErrorCodes.AGENT_SESSION_MISMATCH,
+            "Agent cannot be changed during an MCP session",
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    client_ip = request.client.host if request.client else None
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        client_ip = forwarded_for.split(",", 1)[0].strip()
+
+    claims["_resolved_agent_id"] = str(resolved_agent.id)
+    claims["agent_id"] = str(resolved_agent.id)
+    claims["_client_ip"] = client_ip
+    claims["_request_id"] = request.headers.get("x-request-id") or str(uuid.uuid4())
+    claims["_jti"] = claims.get("jti")
+    claims["_gateway_session_key"] = _gateway_session_key(claims)
+    return claims
+
+
+async def _validated_claims_from_websocket(websocket: WebSocket) -> dict[str, Any]:
+    token = _extract_bearer_token(websocket.headers.get("authorization"))
+    claims = get_validated_token(token, required_scopes=["mcp:connect"], resource=MCP_CANONICAL_URI)
+
+    org_id = claims.get("org_id")
+    env_id = claims.get("env_id")
+    if not org_id or not env_id:
+        raise ValueError("Token missing org_id or env_id claims")
+
+    resolved_agent = await sync_to_async(resolve_agent_from_token_claims)(
+        claims,
+        str(org_id),
+        str(env_id),
+    )
+    if not resolved_agent:
+        raise ValueError("Agent not found or access denied")
+
+    claims["_resolved_agent_id"] = str(resolved_agent.id)
+    claims["agent_id"] = str(resolved_agent.id)
+    claims["_client_ip"] = websocket.client.host if websocket.client else None
+    claims["_request_id"] = str(uuid.uuid4())
+    claims["_jti"] = claims.get("jti")
+    claims["_gateway_session_key"] = _gateway_session_key(claims)
+    return claims
+
+
+def _gateway_session_key(token_claims: dict[str, Any]) -> str:
+    """Build a stable cache key for gateway session state."""
+    session_id = (
+        token_claims.get("jti")
+        or token_claims.get("_resolved_agent_id")
+        or token_claims.get("agent_id")
+        or token_claims.get("sub")
+        or str(uuid.uuid4())
+    )
+    return f"{GATEWAY_STATE_CACHE_PREFIX}{session_id}"
+
+
+async def _load_gateway_state(session_key: str | None) -> dict[str, Any]:
+    """Load gateway session state from the configured Django cache backend."""
+    if not session_key:
+        return {}
+    state_data = await sync_to_async(cache.get)(session_key)
+    return state_data if isinstance(state_data, dict) else {}
+
+
+async def _save_gateway_state(handler: MCPJsonRpcHandler) -> None:
+    """Persist lightweight handler state for multi-instance gateways."""
+    session_key = handler.context.token_claims.get("_gateway_session_key")
+    if not session_key:
+        return
+
+    await sync_to_async(cache.set)(
+        session_key,
+        {"initialized": handler.initialized},
+        GATEWAY_STATE_TIMEOUT_SECONDS,
+    )
+
+
+async def _build_handler(token_claims: dict[str, Any]) -> MCPJsonRpcHandler:
+    from apps.agents.models import Agent
+    from apps.tenants.models import Environment, Organization
+
+    org_id = token_claims.get("org_id")
+    env_id = token_claims.get("env_id")
+    agent_id = token_claims.get("_resolved_agent_id") or token_claims.get("agent_id")
+
+    org = await sync_to_async(Organization.objects.get)(id=org_id)
+    env = await sync_to_async(Environment.objects.get)(id=env_id, organization=org)
+    agent = None
+    if agent_id:
+        agent = await sync_to_async(
+            Agent.objects.filter(
+                id=agent_id,
+                organization=org,
+                environment=env,
+                enabled=True,
+            ).first
+        )()
+
+    handler = MCPJsonRpcHandler(
+        MCPJsonRpcContext(
+            organization=org,
+            environment=env,
+            agent=agent,
+            token_claims=token_claims,
+            server_name=f"AgentxSuite MCP - {org.name}/{env.name}",
+        )
+    )
+    state_data = await _load_gateway_state(token_claims.get("_gateway_session_key"))
+    handler.initialized = bool(state_data.get("initialized", False))
+    return handler
+
+
+async def _handle_jsonrpc_payload(
+    handler: MCPJsonRpcHandler,
+    payload: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, Any] | list[dict[str, Any]] | None:
+    if isinstance(payload, list):
+        responses = []
+        for message in payload:
+            response = await handler.handle_message(message)
+            await _save_gateway_state(handler)
+            if response is not None:
+                responses.append(response)
+        return responses or None
+
+    response = await handler.handle_message(payload)
+    await _save_gateway_state(handler)
+    return response
+
+
+def _wants_event_stream(request: Request) -> bool:
+    accept = request.headers.get("accept", "")
+    return "text/event-stream" in accept.lower()
+
+
+@app.get("/.well-known/mcp")
+async def mcp_endpoint_get(request: Request):
+    """
+    Streamable HTTP GET opens a server-to-client event stream.
+
+    Non-SSE clients still receive a small discovery document for compatibility.
+    """
+    if _wants_event_stream(request):
+        await _validated_claims_from_request(request)
+
+        async def event_generator():
+            while True:
+                await asyncio.sleep(30)
+                yield {"event": "ping", "data": "{}"}
+
+        return EventSourceResponse(event_generator())
+
+    return {
+        "version": "1.0.0",
+        "transports": {
+            "streamable_http": {
+                "url": "/.well-known/mcp",
+            },
+            "sse": {
+                "url": "/.well-known/mcp/sse"
+            },
+            "websocket": {
+                "url": "/.well-known/mcp/ws"
+            }
+        }
+    }
+
+
+@app.post("/.well-known/mcp")
+async def mcp_streamable_http(request: Request):
+    """
+    Handle MCP JSON-RPC over Streamable HTTP.
+
+    The gateway validates the bearer token server-side and executes
+    tools/call directly via AgentxSuite's run service.
+    """
+    token_claims = await _validated_claims_from_request(request)
+    payload = await request.json()
+    handler = await _build_handler(token_claims)
+    response_payload = await _handle_jsonrpc_payload(handler, payload)
+
+    if response_payload is None:
+        return Response(status_code=status.HTTP_202_ACCEPTED)
+
+    if _wants_event_stream(request):
+        async def event_generator():
+            yield {
+                "event": "message",
+                "data": json.dumps(response_payload),
+            }
+
+        return EventSourceResponse(event_generator())
+
+    return JSONResponse(response_payload)
+
+
+@app.get("/.well-known/mcp/sse")
+async def mcp_sse(request: Request):
+    """
+    Legacy SSE endpoint for MCP clients that still use SSE + messages.
+    """
+    await _validated_claims_from_request(request)
+
+    async def event_generator():
+        base_url = str(request.base_url).rstrip("/")
+        yield {
+            "event": "endpoint",
+            "data": f"{base_url}/.well-known/mcp/messages",
+        }
+        while True:
+            await asyncio.sleep(30)
+            yield {"event": "ping", "data": "{}"}
+
+    return EventSourceResponse(event_generator())
+
+
+@app.post("/.well-known/mcp/messages")
+async def mcp_sse_messages(request: Request):
+    """Handle JSON-RPC messages for legacy SSE clients."""
+    return await mcp_streamable_http(request)
+
+
+@app.websocket("/.well-known/mcp/ws")
+async def mcp_websocket(websocket: WebSocket):
+    """
+    WebSocket compatibility endpoint using the same JSON-RPC handler.
+    """
+    try:
+        token_claims = await _validated_claims_from_websocket(websocket)
+        handler = await _build_handler(token_claims)
+        await websocket.accept()
+
+        while True:
+            message = await websocket.receive_json()
+            response = await _handle_jsonrpc_payload(handler, message)
+            if response is not None:
+                await websocket.send_json(response)
+    except WebSocketDisconnect:
+        logger.info("WebSocket disconnected")
+    except HTTPException as exc:
+        await websocket.close(code=1008, reason=str(exc.detail))
+    except Exception as e:
+        logger.error(f"WebSocket error: {e}")
+        await websocket.close(code=1011, reason=str(e))
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint."""
+    return {"status": "ok", "service": "mcp-gateway"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8091,  # Different port from FastMCP server
+        log_level="info"
+    )
+

--- a/backend/mcp_gateway/requirements.txt
+++ b/backend/mcp_gateway/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.109.0
+uvicorn[standard]>=0.27.0
+httpx>=0.26.0
+sse-starlette>=2.0.0
+python-multipart>=0.0.6
+

--- a/backend/mcp_gateway/tests/test_streamable_http.py
+++ b/backend/mcp_gateway/tests/test_streamable_http.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+import mcp_gateway.main as gateway_module
+from mcp_gateway.main import app
+
+
+class FakeHandler:
+    def __init__(self):
+        self.initialized = False
+        self.context = SimpleNamespace(token_claims={"_gateway_session_key": "test-session"})
+
+    async def handle_message(self, message):
+        if message.get("method") == "initialize":
+            self.initialized = True
+        if message.get("id") is None:
+            return None
+        return {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {"method": message["method"]},
+        }
+
+
+def test_streamable_http_post_returns_jsonrpc_response(monkeypatch):
+    async def validated_claims(_request):
+        return {"org_id": "org-id", "env_id": "env-id", "_resolved_agent_id": "agent-id"}
+
+    async def build_handler(_claims):
+        return FakeHandler()
+
+    monkeypatch.setattr(gateway_module, "_validated_claims_from_request", validated_claims)
+    monkeypatch.setattr(gateway_module, "_build_handler", build_handler)
+
+    client = TestClient(app)
+    response = client.post(
+        "/.well-known/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        headers={"Authorization": "Bearer test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"method": "tools/list"},
+    }
+
+
+def test_streamable_http_post_returns_accepted_for_notifications(monkeypatch):
+    async def validated_claims(_request):
+        return {"org_id": "org-id", "env_id": "env-id", "_resolved_agent_id": "agent-id"}
+
+    async def build_handler(_claims):
+        return FakeHandler()
+
+    monkeypatch.setattr(gateway_module, "_validated_claims_from_request", validated_claims)
+    monkeypatch.setattr(gateway_module, "_build_handler", build_handler)
+
+    client = TestClient(app)
+    response = client.post(
+        "/.well-known/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers={"Authorization": "Bearer test"},
+    )
+
+    assert response.status_code == 202
+    assert response.content == b""
+
+
+def test_streamable_http_persists_initialized_state(monkeypatch):
+    gateway_module.cache.delete("test-session")
+
+    async def validated_claims(_request):
+        return {
+            "org_id": "org-id",
+            "env_id": "env-id",
+            "_resolved_agent_id": "agent-id",
+            "_gateway_session_key": "test-session",
+        }
+
+    async def build_handler(_claims):
+        return FakeHandler()
+
+    monkeypatch.setattr(gateway_module, "_validated_claims_from_request", validated_claims)
+    monkeypatch.setattr(gateway_module, "_build_handler", build_handler)
+
+    client = TestClient(app)
+    response = client.post(
+        "/.well-known/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+        headers={"Authorization": "Bearer test"},
+    )
+
+    assert response.status_code == 200
+    assert gateway_module.cache.get("test-session") == {"initialized": True}

--- a/frontend/app/[locale]/claude-agent/authorize/page.tsx
+++ b/frontend/app/[locale]/claude-agent/authorize/page.tsx
@@ -1,0 +1,11 @@
+import { AppLayout } from "../../layout-app";
+import { ClaudeAgentAuthView } from "@/components/ClaudeAgentAuthView";
+
+export default function ClaudeAgentAuthorizePage() {
+  return (
+    <AppLayout>
+      <ClaudeAgentAuthView />
+    </AppLayout>
+  );
+}
+

--- a/frontend/app/[locale]/claude-agent/callback/page.tsx
+++ b/frontend/app/[locale]/claude-agent/callback/page.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter, useParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { claudeAgentApi } from "@/lib/api";
+import {
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Copy,
+  AlertTriangle,
+  ArrowRight,
+  Key,
+} from "lucide-react";
+
+export default function ClaudeAgentCallbackPage() {
+  const t = useTranslations();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const params = useParams();
+  const locale = (params?.locale as string) || "en";
+  
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [tokenInfo, setTokenInfo] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      try {
+        // Get code and state from URL
+        const code = searchParams?.get("code");
+        const state = searchParams?.get("state");
+        const errorParam = searchParams?.get("error");
+        const errorDescription = searchParams?.get("error_description");
+
+        // Check for OAuth error
+        if (errorParam) {
+          throw new Error(errorDescription || errorParam);
+        }
+
+        // Validate required parameters
+        if (!code) {
+          throw new Error("Authorization code not found in URL");
+        }
+
+        // Verify state token (CSRF protection)
+        const storedState = sessionStorage.getItem("claude_oauth_state");
+        if (storedState && state !== storedState) {
+          throw new Error("State mismatch - possible CSRF attack");
+        }
+
+        // Clear stored state
+        sessionStorage.removeItem("claude_oauth_state");
+
+        // Exchange code for token
+        const response = await claudeAgentApi.exchangeToken({
+          code: code,
+          state: state || undefined,
+        });
+
+        // Success!
+        setAccessToken(response.data.access_token);
+        setTokenInfo(response.data);
+        setStatus("success");
+      } catch (err: any) {
+        console.error("OAuth callback error:", err);
+        setError(
+          err.response?.data?.error_description ||
+          err.response?.data?.error ||
+          err.message ||
+          "Failed to exchange authorization code"
+        );
+        setStatus("error");
+      }
+    };
+
+    handleCallback();
+  }, [searchParams]);
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  const handleDone = () => {
+    router.push(`/${locale}/claude-agent/authorize`);
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center p-4">
+      <div className="max-w-2xl w-full">
+        {status === "loading" && (
+          <div className="text-center space-y-6">
+            <div className="inline-flex items-center justify-center w-16 h-16 bg-purple-500/20 rounded-full">
+              <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-white mb-2">
+                Processing Authorization...
+              </h1>
+              <p className="text-slate-400">
+                Exchanging authorization code for access token
+              </p>
+            </div>
+          </div>
+        )}
+
+        {status === "success" && accessToken && (
+          <div className="bg-slate-900 border border-slate-800 rounded-lg p-8 space-y-6">
+            <div className="text-center space-y-4">
+              <div className="inline-flex items-center justify-center w-16 h-16 bg-green-500/20 rounded-full">
+                <CheckCircle2 className="w-8 h-8 text-green-400" />
+              </div>
+              <div>
+                <h1 className="text-2xl font-bold text-white mb-2">
+                  {t("oauth.success")}
+                </h1>
+                <p className="text-slate-400">
+                  Your Claude agent now has access to AgentxSuite
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              {/* Access Token */}
+              <div>
+                <label className="block text-sm font-medium text-slate-300 mb-2 flex items-center gap-2">
+                  <Key className="w-4 h-4 text-purple-400" />
+                  Access Token
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={accessToken}
+                    readOnly
+                    className="flex-1 px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-slate-300 font-mono text-sm"
+                  />
+                  <button
+                    onClick={() => {
+                      copyToClipboard(accessToken);
+                    }}
+                    className="px-4 py-2 bg-purple-500 hover:bg-purple-600 text-white rounded-lg transition-colors flex items-center gap-2"
+                  >
+                    <Copy className="w-4 h-4" />
+                    {copied ? "Copied!" : t("oauth.copyToken")}
+                  </button>
+                </div>
+                <p className="mt-2 text-xs text-slate-500">
+                  Store this token securely. It will be used to authenticate API requests.
+                </p>
+              </div>
+
+              {/* Token Info */}
+              {tokenInfo && (
+                <div className="bg-slate-800/50 rounded-lg p-4 space-y-3">
+                  <h3 className="text-sm font-semibold text-white">Token Information</h3>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <span className="text-slate-500">Token Type:</span>
+                      <span className="ml-2 text-white">{tokenInfo.token_type}</span>
+                    </div>
+                    <div>
+                      <span className="text-slate-500">Expires In:</span>
+                      <span className="ml-2 text-white">
+                        {Math.floor(tokenInfo.expires_in / 3600)} hours
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-slate-500">Scopes:</span>
+                      <span className="ml-2 text-white">{tokenInfo.scope}</span>
+                    </div>
+                    <div>
+                      <span className="text-slate-500">Organization:</span>
+                      <span className="ml-2 text-white font-mono text-xs">
+                        {tokenInfo.organization_id?.substring(0, 8)}...
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Usage Instructions */}
+              <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4">
+                <h3 className="text-sm font-semibold text-blue-300 mb-2">
+                  How to use this token:
+                </h3>
+                <ol className="list-decimal list-inside space-y-1 text-sm text-blue-400/90">
+                  <li>Copy the access token above</li>
+                  <li>Add it to your Claude agent configuration</li>
+                  <li>Use it in the Authorization header: <code className="font-mono text-xs bg-blue-500/20 px-1 rounded">Bearer {"{token}"}</code></li>
+                  <li>Make API calls to AgentxSuite endpoints</li>
+                </ol>
+              </div>
+
+              {/* Actions */}
+              <div className="flex justify-center pt-4">
+                <button
+                  onClick={handleDone}
+                  className="px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white rounded-lg font-semibold transition-all shadow-lg hover:shadow-purple-500/50 flex items-center gap-2"
+                >
+                  Done
+                  <ArrowRight className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {status === "error" && (
+          <div className="bg-slate-900 border border-red-500/20 rounded-lg p-8 space-y-6">
+            <div className="text-center space-y-4">
+              <div className="inline-flex items-center justify-center w-16 h-16 bg-red-500/20 rounded-full">
+                <XCircle className="w-8 h-8 text-red-400" />
+              </div>
+              <div>
+                <h1 className="text-2xl font-bold text-white mb-2">
+                  Authorization Failed
+                </h1>
+                <p className="text-slate-400">
+                  There was a problem completing the authorization
+                </p>
+              </div>
+            </div>
+
+            {error && (
+              <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="w-5 h-5 text-red-400 mt-0.5 flex-shrink-0" />
+                  <div className="flex-1">
+                    <h3 className="text-sm font-semibold text-red-300 mb-1">Error Details</h3>
+                    <p className="text-sm text-red-400">{error}</p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="flex justify-center pt-4">
+              <button
+                onClick={handleDone}
+                className="px-6 py-3 bg-slate-700 hover:bg-slate-600 text-white rounded-lg font-semibold transition-all flex items-center gap-2"
+              >
+                Back to Authorization
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/components/ClaudeAgentAuthView.tsx
+++ b/frontend/components/ClaudeAgentAuthView.tsx
@@ -1,0 +1,494 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { claudeAgentApi, api } from "@/lib/api";
+import { useAppStore } from "@/lib/store";
+import {
+  Shield,
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  AlertCircle,
+  Key,
+  Globe,
+  Loader2,
+  ArrowRight,
+  Info,
+} from "lucide-react";
+
+interface Toast {
+  id: string;
+  message: string;
+  type: "success" | "error" | "info";
+}
+
+const AVAILABLE_SCOPES = [
+  {
+    name: "agent:execute",
+    description: "Execute agents and tools",
+    default: true,
+  },
+  {
+    name: "tools:read",
+    description: "Read available tools",
+    default: true,
+  },
+  {
+    name: "runs:read",
+    description: "Read execution history",
+    default: false,
+  },
+  {
+    name: "agent:read",
+    description: "Read agent information",
+    default: false,
+  },
+];
+
+export function ClaudeAgentAuthView() {
+  const t = useTranslations();
+  const { currentOrgId: orgId, currentEnvId: envId, setCurrentOrg, setCurrentEnv } = useAppStore();
+  const [selectedScopes, setSelectedScopes] = useState<string[]>(
+    AVAILABLE_SCOPES.filter((s) => s.default).map((s) => s.name)
+  );
+  const [authorizationUrl, setAuthorizationUrl] = useState<string | null>(null);
+  const [generatedState, setGeneratedState] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [tokenInfo, setTokenInfo] = useState<any>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const [redirectUri, setRedirectUri] = useState("");
+
+  // Fetch organizations
+  const { data: orgsResponse } = useQuery({
+    queryKey: ["my-organizations"],
+    queryFn: async () => {
+      const response = await api.get("/auth/me/orgs/");
+      return Array.isArray(response.data) 
+        ? response.data 
+        : response.data?.organizations || [];
+    },
+  });
+
+  const organizations = Array.isArray(orgsResponse) ? orgsResponse : (orgsResponse?.organizations || []);
+
+  useEffect(() => {
+    if (!orgId && organizations && organizations.length > 0) {
+      setCurrentOrg(organizations[0].id);
+    }
+  }, [organizations, orgId, setCurrentOrg]);
+
+  // Fetch environments
+  const { data: environmentsData } = useQuery({
+    queryKey: ["environments", orgId],
+    queryFn: async () => {
+      if (!orgId) return [];
+      const response = await api.get(`/orgs/${orgId}/environments/`);
+      return Array.isArray(response.data) 
+        ? response.data 
+        : response.data?.results || [];
+    },
+    enabled: !!orgId,
+  });
+
+  const environments = Array.isArray(environmentsData) ? environmentsData : [];
+
+  // Auto-select first environment
+  useEffect(() => {
+    if (!envId && environments && environments.length > 0) {
+      setCurrentEnv(environments[0].id);
+    }
+  }, [environments, envId, setCurrentEnv]);
+
+  // Set default redirect URI
+  useEffect(() => {
+    if (typeof window !== "undefined" && !redirectUri) {
+      const baseUrl = window.location.origin;
+      const locale = window.location.pathname.split("/")[1] || "en";
+      setRedirectUri(`${baseUrl}/${locale}/claude-agent/callback`);
+    }
+  }, [redirectUri]);
+
+  // Fetch manifest
+  const { data: manifest } = useQuery({
+    queryKey: ["claude-agent-manifest"],
+    queryFn: async () => {
+      const response = await claudeAgentApi.getManifest();
+      return response.data;
+    },
+  });
+
+  const addToast = (message: string, type: "success" | "error" | "info" = "success") => {
+    const id = Date.now().toString();
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 5000);
+  };
+
+  const copyToClipboard = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(label);
+      setTimeout(() => setCopied(null), 2000);
+      addToast(`${label} copied to clipboard`, "success");
+    } catch (err) {
+      addToast("Failed to copy to clipboard", "error");
+    }
+  };
+
+  const toggleScope = (scope: string) => {
+    setSelectedScopes((prev) =>
+      prev.includes(scope)
+        ? prev.filter((s) => s !== scope)
+        : [...prev, scope]
+    );
+  };
+
+  // Initiate OAuth flow mutation
+  const initiateMutation = useMutation({
+    mutationFn: async () => {
+      if (!orgId || !envId) {
+        throw new Error("Please select organization and environment");
+      }
+
+      // Call backend to initiate OAuth flow
+      // This generates a secure state token and stores it in the cache
+      const response = await claudeAgentApi.initiateAuth({
+        organization_id: orgId,
+        environment_id: envId,
+        scopes: selectedScopes,
+        redirect_uri: redirectUri,
+      });
+
+      const authUrl = response.data.authorization_url;
+      const state = response.data.state;
+
+      setGeneratedState(state);
+      setAuthorizationUrl(authUrl);
+      
+      return authUrl;
+    },
+    onSuccess: () => {
+      addToast("Authorization URL generated", "success");
+    },
+    onError: (error: any) => {
+      addToast(
+        error.response?.data?.error || error.message || "Failed to initiate OAuth flow",
+        "error"
+      );
+    },
+  });
+
+  const handleInitiate = () => {
+    initiateMutation.mutate();
+  };
+
+  const handleOpenAuthUrl = () => {
+    if (authorizationUrl) {
+      // Store state in sessionStorage for verification
+      if (generatedState) {
+        sessionStorage.setItem("claude_oauth_state", generatedState);
+      }
+      window.open(authorizationUrl, "_blank");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 p-4 md:p-8">
+      {/* Toasts */}
+      <div className="fixed top-4 right-4 z-50 space-y-2">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={`flex items-center gap-2 px-4 py-3 rounded-lg border shadow-lg ${
+              toast.type === "success"
+                ? "bg-green-500/10 border-green-500/20 text-green-400"
+                : toast.type === "error"
+                ? "bg-red-500/10 border-red-500/20 text-red-400"
+                : "bg-blue-500/10 border-blue-500/20 text-blue-400"
+            }`}
+          >
+            {toast.type === "success" ? (
+              <CheckCircle2 className="w-5 h-5" />
+            ) : toast.type === "error" ? (
+              <AlertCircle className="w-5 h-5" />
+            ) : (
+              <Info className="w-5 h-5" />
+            )}
+            <span className="text-sm">{toast.message}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="max-w-4xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="text-center space-y-2">
+          <div className="inline-flex items-center justify-center w-16 h-16 bg-purple-500/20 rounded-full mb-4">
+            <Shield className="w-8 h-8 text-purple-400" />
+          </div>
+          <h1 className="text-3xl font-bold text-white">
+            {t("oauth.title")}
+          </h1>
+          <p className="text-slate-400 max-w-2xl mx-auto">
+            Grant Claude Hosted Agents access to AgentxSuite tools and capabilities via OAuth 2.0
+          </p>
+        </div>
+
+        {/* Organization & Environment Selection */}
+        <div className="bg-slate-900 border border-slate-800 rounded-lg p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+            <Globe className="w-5 h-5 text-purple-400" />
+            Organization & Environment
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-2">
+                {t("oauth.selectOrg")}
+              </label>
+              <select
+                value={orgId || ""}
+                onChange={(e) => {
+                  setCurrentOrg(e.target.value);
+                  setCurrentEnv(null);
+                  setAuthorizationUrl(null);
+                  setAccessToken(null);
+                }}
+                className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+              >
+                {organizations.map((org: any) => (
+                  <option key={org.id} value={org.id}>
+                    {org.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-2">
+                {t("oauth.selectEnv")}
+              </label>
+              <select
+                value={envId || ""}
+                onChange={(e) => {
+                  setCurrentEnv(e.target.value);
+                  setAuthorizationUrl(null);
+                  setAccessToken(null);
+                }}
+                className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+                disabled={!orgId}
+              >
+                {environments.map((env: any) => (
+                  <option key={env.id} value={env.id}>
+                    {env.name} ({env.type})
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {/* Redirect URI Configuration */}
+        <div className="bg-slate-900 border border-slate-800 rounded-lg p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+            <ExternalLink className="w-5 h-5 text-purple-400" />
+            Redirect URI
+          </h2>
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-2">
+              Callback URL
+            </label>
+            <input
+              type="text"
+              value={redirectUri}
+              onChange={(e) => setRedirectUri(e.target.value)}
+              placeholder="https://your-domain.com/callback"
+              className="w-full px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
+            />
+            <p className="mt-2 text-xs text-slate-500">
+              The URL where users will be redirected after authorization
+            </p>
+          </div>
+        </div>
+
+        {/* Scope Selection */}
+        <div className="bg-slate-900 border border-slate-800 rounded-lg p-6 space-y-4">
+          <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+            <Key className="w-5 h-5 text-purple-400" />
+            {t("oauth.selectScopes")}
+          </h2>
+          <div className="space-y-2">
+            {AVAILABLE_SCOPES.map((scope) => (
+              <label
+                key={scope.name}
+                className="flex items-start gap-3 p-3 bg-slate-800/50 hover:bg-slate-800 rounded-lg cursor-pointer transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedScopes.includes(scope.name)}
+                  onChange={() => toggleScope(scope.name)}
+                  className="mt-0.5 w-4 h-4 rounded border-slate-600 text-purple-500 focus:ring-2 focus:ring-purple-500"
+                />
+                <div className="flex-1">
+                  <div className="font-medium text-white">{scope.name}</div>
+                  <div className="text-sm text-slate-400">{scope.description}</div>
+                </div>
+                {scope.default && (
+                  <span className="px-2 py-0.5 text-xs bg-purple-500/20 text-purple-400 rounded">
+                    Recommended
+                  </span>
+                )}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Generate Authorization Button */}
+        <div className="flex justify-center">
+          <button
+            onClick={handleInitiate}
+            disabled={!orgId || !envId || selectedScopes.length === 0 || initiateMutation.isPending}
+            className="px-6 py-3 bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white rounded-lg font-semibold transition-all shadow-lg hover:shadow-purple-500/50 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {initiateMutation.isPending ? (
+              <>
+                <Loader2 className="w-5 h-5 animate-spin" />
+                Generating...
+              </>
+            ) : (
+              <>
+                <Shield className="w-5 h-5" />
+                {t("oauth.authorize")}
+              </>
+            )}
+          </button>
+        </div>
+
+        {/* Authorization URL Result */}
+        {authorizationUrl && (
+          <div className="bg-slate-900 border border-slate-800 rounded-lg p-6 space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-white flex items-center gap-2">
+                <CheckCircle2 className="w-5 h-5 text-green-400" />
+                {t("oauth.success")}
+              </h2>
+            </div>
+            
+            <div className="space-y-3">
+              {/* Authorization URL */}
+              <div>
+                <label className="block text-sm font-medium text-slate-300 mb-2">
+                  Authorization URL
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={authorizationUrl}
+                    readOnly
+                    className="flex-1 px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-slate-300 font-mono text-sm"
+                  />
+                  <button
+                    onClick={() => {
+                      copyToClipboard(authorizationUrl, "Authorization URL");
+                    }}
+                    className="px-3 py-2 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg transition-colors"
+                    title="Copy URL"
+                  >
+                    <Copy className={`w-4 h-4 ${copied === "Authorization URL" ? "text-green-400" : "text-slate-400"}`} />
+                  </button>
+                </div>
+              </div>
+
+              {/* State Token */}
+              {generatedState && (
+                <div>
+                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                    State Token (for verification)
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={generatedState}
+                      readOnly
+                      className="flex-1 px-3 py-2 bg-slate-800 border border-slate-700 rounded-lg text-slate-300 font-mono text-sm"
+                    />
+                  <button
+                    onClick={() => {
+                      copyToClipboard(generatedState, "State Token");
+                    }}
+                    className="px-3 py-2 bg-slate-800 hover:bg-slate-700 border border-slate-700 rounded-lg transition-colors"
+                    title="Copy State"
+                  >
+                    <Copy className={`w-4 h-4 ${copied === "State Token" ? "text-green-400" : "text-slate-400"}`} />
+                  </button>
+                  </div>
+                  <p className="mt-2 text-xs text-slate-500">
+                    Store this state token securely. You'll need it to verify the callback.
+                  </p>
+                </div>
+              )}
+
+              {/* Open Authorization Button */}
+              <div className="flex justify-center pt-4">
+                <button
+                  onClick={handleOpenAuthUrl}
+                  className="px-6 py-3 bg-purple-500 hover:bg-purple-600 text-white rounded-lg font-semibold transition-all flex items-center gap-2"
+                >
+                  Open Authorization Page
+                  <ArrowRight className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Instructions */}
+        <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-6">
+          <div className="flex items-start gap-3">
+            <Info className="w-5 h-5 text-blue-400 mt-0.5 flex-shrink-0" />
+            <div className="space-y-2 text-sm text-blue-300">
+              <p className="font-semibold">How to use:</p>
+              <ol className="list-decimal list-inside space-y-1 text-blue-400/90">
+                <li>Select your organization and environment</li>
+                <li>Choose the scopes (permissions) you want to grant</li>
+                <li>Click "Generate Authorization URL"</li>
+                <li>Open the authorization page and approve the request</li>
+                <li>You'll be redirected back with an access token</li>
+                <li>Use the access token to make API calls from Claude agents</li>
+              </ol>
+            </div>
+          </div>
+        </div>
+
+        {/* Manifest Info */}
+        {manifest && (
+          <div className="bg-slate-900 border border-slate-800 rounded-lg p-6">
+            <h3 className="text-lg font-semibold text-white mb-4">
+              AgentxSuite Agent Manifest
+            </h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+              <div>
+                <span className="text-slate-500">Name:</span>
+                <span className="ml-2 text-white">{manifest.name}</span>
+              </div>
+              <div>
+                <span className="text-slate-500">Version:</span>
+                <span className="ml-2 text-white">{manifest.version}</span>
+              </div>
+              <div>
+                <span className="text-slate-500">Available Tools:</span>
+                <span className="ml-2 text-white">{manifest.tools?.length || 0}</span>
+              </div>
+              <div>
+                <span className="text-slate-500">Auth Type:</span>
+                <span className="ml-2 text-white">{manifest.authentication?.type}</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Network,
   DollarSign,
   Package,
+  // Sparkles, // Nicht mehr benötigt, Claude Agent ausgeblendet
 } from "lucide-react";
 import { useAuthStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
@@ -41,6 +42,7 @@ const navItems = [
   { href: "/environments", icon: Globe, key: "environments" },
   { href: "/mcp-connect", icon: Wifi, key: "mcpConnect" },
   { href: "/mcp-hub", icon: Package, key: "mcpHub" },
+  // { href: "/claude-agent/authorize", icon: Sparkles, key: "claudeAgent" }, // Ausgeblendet - OAuth für Hosted Agents noch nicht verfügbar
   { href: "/audit", icon: FileText, key: "audit" },
   { href: "/settings", icon: Settings, key: "settings" },
 ];

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import type { Resource, Prompt, Policy, PolicyRule, PolicyBinding, PolicyEvaluateRequest, Agent, IssuedToken, TokenGenerateRequest, TokenGenerateResponse, ServiceAccount, RunList, RunDetail, MCPServerRegistration, ClaudeDesktopConfig, CostSummary, AgentCostSummary, EnvironmentCostSummary, ModelCostSummary, ToolCostSummary } from "./types";
+import type { Resource, Prompt, Policy, PolicyRule, PolicyBinding, PolicyEvaluateRequest, Agent, IssuedToken, TokenGenerateRequest, TokenGenerateResponse, ServiceAccount, RunList, RunDetail, MCPServerRegistration, ClaudeDesktopConfig, CostSummary, AgentCostSummary, EnvironmentCostSummary, ModelCostSummary, ToolCostSummary, OAuthAuthorizationRequest, OAuthAuthorizationResponse, OAuthTokenRequest, OAuthTokenResponse, OAuthRevokeRequest, ClaudeAgentExecutionRequest, ClaudeAgentExecutionResponse, ClaudeAgentManifest, ClaudeAgentTool } from "./types";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
 
@@ -324,6 +324,67 @@ export const costsApi = {
   // Get cost breakdown by tool
   byTool: (orgId: string, params?: { environment?: string; days?: number }) =>
     api.get<ToolCostSummary[]>(`/orgs/${orgId}/costs/by_tool/`, { params }),
+};
+
+// Claude Agent SDK API
+export const claudeAgentApi = {
+  // Get agent manifest
+  getManifest: () => 
+    api.get<ClaudeAgentManifest>("/claude-agent/manifest"),
+  
+  // Get OpenAPI specification
+  getOpenAPI: () => 
+    api.get("/claude-agent/openapi.json"),
+  
+  // Initiate OAuth authorization flow
+  initiateAuth: (data: OAuthAuthorizationRequest) =>
+    api.post<OAuthAuthorizationResponse>("/claude-agent/oauth/initiate", data),
+  
+  // Get authorization URL (for redirecting user)
+  getAuthUrl: (params: {
+    organization_id: string;
+    environment_id: string;
+    scopes?: string[];
+    state?: string;
+    redirect_uri?: string;
+  }) => {
+    const searchParams = new URLSearchParams();
+    searchParams.append("organization_id", params.organization_id);
+    searchParams.append("environment_id", params.environment_id);
+    if (params.scopes && params.scopes.length > 0) {
+      searchParams.append("scope", params.scopes.join(" "));
+    }
+    if (params.state) {
+      searchParams.append("state", params.state);
+    }
+    if (params.redirect_uri) {
+      searchParams.append("redirect_uri", params.redirect_uri);
+    }
+    return `${API_BASE_URL}/claude-agent/authorize?${searchParams.toString()}`;
+  },
+  
+  // Exchange authorization code for access token
+  exchangeToken: (data: OAuthTokenRequest) =>
+    api.post<OAuthTokenResponse>("/claude-agent/token", {
+      grant_type: "authorization_code",
+      ...data,
+    }),
+  
+  // Revoke access token
+  revokeToken: (data: OAuthRevokeRequest) =>
+    api.post("/claude-agent/revoke", data),
+  
+  // List available tools
+  listTools: () =>
+    api.get<ClaudeAgentTool[]>("/claude-agent/tools"),
+  
+  // Execute agent with message
+  execute: (data: ClaudeAgentExecutionRequest) =>
+    api.post<ClaudeAgentExecutionResponse>("/claude-agent/execute", data),
+  
+  // Health check
+  health: () =>
+    api.get("/claude-agent/health"),
 };
 
 export default api;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -434,12 +434,117 @@ export interface Connection {
   organization: Organization;
   environment: Environment;
   name: string;
-  endpoint: string;
+  transport: "stdio" | "streamable_http" | "sse" | "legacy_http";
+  endpoint: string | null;
+  command: string;
+  args: string[];
   auth_method: "none" | "bearer" | "basic";
   secret_ref?: string | null;
+  env_ref?: string | null;
   status: "unknown" | "ok" | "fail";
   last_seen_at?: string | null;
   created_at: string;
   updated_at: string;
+}
+
+// Claude Agent OAuth Types
+export interface OAuthAuthorizationRequest {
+  organization_id: string;
+  environment_id: string;
+  scopes: string[];
+  state?: string;
+  redirect_uri?: string;
+}
+
+export interface OAuthAuthorizationResponse {
+  authorization_url: string;
+  state: string;
+  expires_at: string;
+}
+
+export interface OAuthTokenRequest {
+  code: string;
+  state?: string;
+  redirect_uri?: string;
+}
+
+export interface OAuthTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  scope: string;
+  organization_id: string;
+  environment_id: string;
+  created_at: string;
+}
+
+export interface OAuthRevokeRequest {
+  token: string;
+}
+
+// Claude Agent Execution Types
+export interface MCPServerConfig {
+  type: "url" | "stdio";
+  url?: string;
+  name: string;
+  authorization_token?: string;
+}
+
+export interface ClaudeAgentExecutionRequest {
+  message: string;
+  organization_id: string;
+  environment_id: string;
+  model?: string;
+  system_prompt?: string;
+  mcp_servers?: MCPServerConfig[];
+  max_tokens?: number;
+}
+
+export interface ClaudeToolCall {
+  tool_name: string;
+  tool_input: Record<string, any>;
+  tool_output: Record<string, any>;
+  status: "success" | "error";
+  execution_time_ms?: number;
+}
+
+export interface ClaudeAgentCost {
+  total_cost: number;
+  input_tokens: number;
+  output_tokens: number;
+  model: string;
+}
+
+export interface ClaudeAgentExecutionResponse {
+  response: string;
+  tool_calls: ClaudeToolCall[];
+  cost: ClaudeAgentCost;
+  conversation_id?: string;
+  model: string;
+}
+
+export interface ClaudeAgentTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, any>;
+}
+
+export interface ClaudeAgentManifest {
+  schema_version: string;
+  name: string;
+  display_name: string;
+  description: string;
+  version: string;
+  authentication: {
+    type: string;
+    oauth2?: {
+      authorization_url: string;
+      token_url: string;
+      scopes: Record<string, string>;
+      default_scopes: string[];
+    };
+  };
+  tools: ClaudeAgentTool[];
+  capabilities: Record<string, boolean>;
 }
 

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -47,6 +47,7 @@
     "environments": "Umgebungen",
     "mcpConnect": "MCP Verbinden",
     "mcpHub": "MCP Hub",
+    "claudeAgent": "Claude Agent",
     "audit": "Audit & Logs",
     "settings": "Einstellungen",
     "resources": "Resources",
@@ -264,6 +265,33 @@
       "button": "Zu Cursor hinzufügen",
       "hint": "Öffnet Cursor mit Verbindungsaufforderung."
     }
+  },
+  "oauth": {
+    "title": "Claude Agent autorisieren",
+    "selectOrg": "Organization",
+    "selectEnv": "Environment",
+    "selectScopes": "Scopes auswählen",
+    "authorize": "Autorisierungs-URL generieren",
+    "success": "Autorisierung erfolgreich",
+    "copyToken": "Token kopieren",
+    "tokenCopied": "Token in Zwischenablage kopiert"
+  },
+  "claudeAgent": {
+    "title": "Claude Agent",
+    "auth": "Agent autorisieren",
+    "execute": "Agent ausführen",
+    "chat": "Chat mit Claude",
+    "selectModel": "Modell auswählen",
+    "systemPrompt": "System Prompt",
+    "mcpServers": "Externe MCP Server",
+    "send": "Senden",
+    "toolCalls": "Tool-Aufrufe",
+    "cost": "Kosten",
+    "tokens": "Tokens",
+    "model": "Modell",
+    "inputTokens": "Input Tokens",
+    "outputTokens": "Output Tokens",
+    "totalCost": "Gesamtkosten"
   }
 }
 

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -47,6 +47,7 @@
     "environments": "Environments",
     "mcpConnect": "MCP Connect",
     "mcpHub": "MCP Hub",
+    "claudeAgent": "Claude Agent",
     "audit": "Audit & Logs",
     "settings": "Settings",
     "resources": "Resources",
@@ -264,6 +265,33 @@
       "button": "Add to Cursor",
       "hint": "Opens Cursor with connection prompt."
     }
+  },
+  "oauth": {
+    "title": "Authorize Claude Agent",
+    "selectOrg": "Organization",
+    "selectEnv": "Environment",
+    "selectScopes": "Select Scopes",
+    "authorize": "Generate Authorization URL",
+    "success": "Authorization Successful",
+    "copyToken": "Copy Token",
+    "tokenCopied": "Token copied to clipboard"
+  },
+  "claudeAgent": {
+    "title": "Claude Agent",
+    "auth": "Authorize Agent",
+    "execute": "Execute Agent",
+    "chat": "Chat with Claude",
+    "selectModel": "Select Model",
+    "systemPrompt": "System Prompt",
+    "mcpServers": "External MCP Servers",
+    "send": "Send",
+    "toolCalls": "Tool Calls",
+    "cost": "Cost",
+    "tokens": "Tokens",
+    "model": "Model",
+    "inputTokens": "Input Tokens",
+    "outputTokens": "Output Tokens",
+    "totalCost": "Total Cost"
   }
 }
 


### PR DESCRIPTION
## Purpose
Governance hardening for the Claude Agent integration plus frontend wiring.

## Changes
- claude_agent: short-lived OAuth access tokens bounded by `MCP_TOKEN_MAX_TTL_MINUTES`, login/authorize templates, revoke flow
- mcp_ext: link `MCPServerRegistration` to `Connection` (+ migration), serializer/view updates
- audit: align audit events with the new execution flow
- frontend: Claude Agent authorize/callback pages, `ClaudeAgentAuthView`, API/types, sidebar entry, de/en messages

## Tests
- claude_agent/tests/test_oauth.py, mcp_ext/tests/test_mcp_server_registration.py

## Migrations
- mcp_ext 0005 (registration -> connection)

## Note
Stacked PR (base: feat/mcp-gateway-fabric). Merge PR #3 and #4 first.