### PR TITLE
feat(mcp): inbound MCP server surface - gateway + fabric (P1)

### DIFF
--- a/DEPLOYMENT_MCP_GATEWAY.md
+++ b/DEPLOYMENT_MCP_GATEWAY.md
@@ -1,0 +1,372 @@
+# MCP Gateway Deployment Guide
+
+Complete guide to deploy the MCP Gateway service for AgentxSuite.
+
+## 🎯 What You're Deploying
+
+A server-side bridge that allows Claude Desktop users to connect **without installing a local bridge**.
+
+```
+User Flow:
+Claude Desktop → mcp.agentxsuite.com (Gateway) → FastMCP Backend
+```
+
+## 📦 Prerequisites
+
+- Server with Python 3.11+
+- Domain for gateway (e.g., `mcp.agentxsuite.com`)
+- SSL certificate
+- Nginx or similar reverse proxy
+
+## 🚀 Quick Start (Development)
+
+```bash
+# 1. Install dependencies
+cd backend/mcp_gateway
+pip install -r requirements.txt
+
+# 2. Start gateway
+python main.py
+
+# Gateway runs on http://localhost:8091
+
+# 3. Start FastMCP (in another terminal)
+cd backend
+make run-mcp-fabric
+
+# FastMCP runs on http://localhost:8090
+```
+
+**Test it:**
+```bash
+curl http://localhost:8091/health
+# Should return: {"status":"ok","service":"mcp-gateway"}
+```
+
+## 🏭 Production Deployment
+
+### Option 1: Docker (Recommended)
+
+```bash
+# Build image
+cd backend/mcp_gateway
+docker build -t agentxsuite-mcp-gateway .
+
+# Run with docker-compose
+docker-compose up -d
+
+# Check logs
+docker-compose logs -f mcp-gateway
+```
+
+### Option 2: Systemd Service
+
+**1. Create systemd service:**
+
+```bash
+sudo nano /etc/systemd/system/mcp-gateway.service
+```
+
+**Paste:**
+```ini
+[Unit]
+Description=AgentxSuite MCP Gateway
+After=network.target mcp-fabric.service
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/agentxsuite/backend
+Environment="PATH=/opt/agentxsuite/venv/bin"
+Environment="FASTMCP_BACKEND_URL=http://localhost:8090"
+ExecStart=/opt/agentxsuite/venv/bin/python mcp_gateway/main.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**2. Enable and start:**
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable mcp-gateway
+sudo systemctl start mcp-gateway
+sudo systemctl status mcp-gateway
+```
+
+### Option 3: Supervisor
+
+```bash
+sudo nano /etc/supervisor/conf.d/mcp-gateway.conf
+```
+
+```ini
+[program:mcp-gateway]
+command=/opt/agentxsuite/venv/bin/python mcp_gateway/main.py
+directory=/opt/agentxsuite/backend
+user=www-data
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/mcp-gateway.err.log
+stdout_logfile=/var/log/mcp-gateway.out.log
+environment=FASTMCP_BACKEND_URL="http://localhost:8090"
+```
+
+## 🔧 Nginx Configuration
+
+### Basic Setup
+
+```nginx
+upstream mcp_gateway {
+    server localhost:8091;
+    keepalive 32;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name mcp.agentxsuite.com;
+
+    ssl_certificate /etc/letsencrypt/live/mcp.agentxsuite.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mcp.agentxsuite.com/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    # SSE endpoint - critical configuration!
+    location /.well-known/mcp/sse {
+        proxy_pass http://mcp_gateway;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Critical for SSE
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        chunked_transfer_encoding off;
+    }
+
+    # WebSocket endpoint
+    location /.well-known/mcp/ws {
+        proxy_pass http://mcp_gateway;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 86400s;
+    }
+
+    # Other endpoints
+    location / {
+        proxy_pass http://mcp_gateway;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    server_name mcp.agentxsuite.com;
+    return 301 https://$server_name$request_uri;
+}
+```
+
+**Apply config:**
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## 🔐 SSL Certificate (Let's Encrypt)
+
+```bash
+# Install certbot
+sudo apt install certbot python3-certbot-nginx
+
+# Get certificate
+sudo certbot --nginx -d mcp.agentxsuite.com
+
+# Auto-renewal is configured automatically
+```
+
+## 📊 Monitoring
+
+### Health Checks
+
+```bash
+# Basic health
+curl https://mcp.agentxsuite.com/health
+
+# SSE endpoint
+curl -N -H "Authorization: Bearer TOKEN" \
+  https://mcp.agentxsuite.com/.well-known/mcp/sse
+```
+
+### Logs
+
+**Docker:**
+```bash
+docker-compose logs -f mcp-gateway
+```
+
+**Systemd:**
+```bash
+journalctl -u mcp-gateway -f
+```
+
+**Supervisor:**
+```bash
+tail -f /var/log/mcp-gateway.out.log
+```
+
+### Metrics
+
+Add to your monitoring (Prometheus, Grafana):
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: 'mcp-gateway'
+    static_configs:
+      - targets: ['localhost:8091']
+```
+
+## 🧪 Testing
+
+### Test SSE Connection
+
+```bash
+curl -N -H "Authorization: Bearer YOUR_TOKEN" \
+  https://mcp.agentxsuite.com/.well-known/mcp/sse
+```
+
+Should stream events continuously.
+
+### Test WebSocket
+
+```bash
+npm install -g wscat
+
+wscat -c wss://mcp.agentxsuite.com/.well-known/mcp/ws \
+  -H "Authorization: Bearer YOUR_TOKEN"
+
+# Then send:
+{"jsonrpc":"2.0","method":"tools/list","params":{},"id":1}
+```
+
+### Test from Claude Desktop
+
+**Config:**
+```json
+{
+  "mcpServers": {
+    "agentxsuite": {
+      "url": "https://mcp.agentxsuite.com/.well-known/mcp/sse",
+      "transport": "sse",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+**Restart Claude Desktop and test!**
+
+## 🚨 Troubleshooting
+
+### Gateway won't start
+
+**Check port 8091:**
+```bash
+lsof -i :8091
+# Kill if needed:
+kill -9 $(lsof -t -i:8091)
+```
+
+**Check backend connection:**
+```bash
+curl http://localhost:8090/health
+# Should work before gateway can
+```
+
+### SSE connection drops
+
+**Check nginx timeout:**
+```nginx
+proxy_read_timeout 86400s;  # 24 hours
+```
+
+**Check system limits:**
+```bash
+ulimit -n  # Should be > 1024
+```
+
+### High memory usage
+
+**Limit connections:**
+```python
+# In mcp_gateway/main.py
+app = FastAPI(
+    ...
+    max_request_size=1024*1024,  # 1MB
+)
+```
+
+## 📈 Scaling
+
+### Load Balancing (Multiple Gateways)
+
+```nginx
+upstream mcp_gateway {
+    least_conn;
+    server gateway1:8091;
+    server gateway2:8091;
+    server gateway3:8091;
+}
+```
+
+### Redis for Session State (Future)
+
+```python
+# For stateful connections
+import redis
+r = redis.Redis(host='localhost', port=6379)
+```
+
+## 🔒 Security Checklist
+
+- [x] HTTPS enforced
+- [x] Token validation on every request
+- [x] Rate limiting configured
+- [x] CORS properly configured
+- [x] Logs don't contain tokens
+- [x] Regular security updates
+- [x] Firewall rules applied
+
+## 📚 Additional Resources
+
+- User Guide: `/docs/USER_GUIDE_MCP_GATEWAY.md`
+- Gateway README: `/backend/mcp_gateway/README.md`
+- FastMCP Docs: https://github.com/jlowin/fastmcp
+
+## 🎉 Success Checklist
+
+- [ ] Gateway health endpoint returns OK
+- [ ] SSE endpoint streams events
+- [ ] Claude Desktop can connect
+- [ ] Tools are callable from Claude
+- [ ] Logs show successful requests
+- [ ] SSL certificate is valid
+- [ ] Monitoring is set up
+
+Congratulations! Your users can now use AgentxSuite **without any local bridge**! 🚀
+

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -7,9 +7,11 @@ from django.contrib import admin
 from django.urls import include, path
 
 from apps.claude_agent import views as claude_views
+from config.openapi import openapi_schema
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/schema/", openapi_schema, name="api_schema"),
     
     # Well-known endpoints for service discovery
     path(".well-known/agent-manifest", claude_views.wellknown_agent_manifest, name="wellknown_agent_manifest"),

--- a/backend/mcp_fabric/adapters.py
+++ b/backend/mcp_fabric/adapters.py
@@ -6,10 +6,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from apps.agents.models import Agent
-from apps.runs.services import start_run
+from apps.runs.services import ExecutionContext, execute_tool_run
 from apps.tools.models import Tool
-from mcp_fabric.pep import check_policy_before_tool_call
 
 logger = logging.getLogger(__name__)
 
@@ -42,14 +40,8 @@ def run_tool_via_agentxsuite(
         - {"status": "success", "output": {...}, "run_id": "..."}
         - {"status": "error", "error": "error_code", "run_id": "..."}
     """
-    # P0: Use resolved agent_id (from token via subject/issuer mapping)
-    # token_agent_id is now the resolved agent_id from deps (source of truth)
-    # agent_id from payload/query must match or be None
-    
-    final_agent_id = token_agent_id  # Use resolved agent_id (source of truth)
-    
     # If agent_id provided in payload/query, it must match resolved agent_id
-    if agent_id and agent_id != token_agent_id:
+    if agent_id and token_agent_id and agent_id != token_agent_id:
         logger.warning(
             f"Agent ID mismatch: resolved agent_id is '{token_agent_id}' but request specifies '{agent_id}'",
             extra={
@@ -68,96 +60,59 @@ def run_tool_via_agentxsuite(
                 "Agent cannot be changed during session."
             ),
         }
-    
-    # Determine agent (must use resolved agent_id)
-    if final_agent_id:
-        agent = Agent.objects.filter(
+
+    # Execute through the unified service; start_run is the single PDP-backed gate.
+    try:
+        result = execute_tool_run(
             organization=tool.organization,
             environment=tool.environment,
-            id=final_agent_id,
-            enabled=True,
-        ).first()
-        if not agent:
-            logger.warning(
-                f"Agent {final_agent_id} not found for tool {tool.name}",
-                extra={
-                    "tool_id": str(tool.id),
-                    "agent_id": final_agent_id,
-                    "org_id": str(tool.organization.id),
-                    "env_id": str(tool.environment.id),
-                },
-            )
-            return {"status": "error", "error": "agent_not_found"}
-    else:
-        agent = (
-            Agent.objects.filter(
-                organization=tool.organization,
-                environment=tool.environment,
-                enabled=True,
-            )
-            .order_by("-created_at")
-            .first()
+            tool_identifier=str(tool.id),
+            agent_identifier=agent_id,
+            input_data=payload,
+            context=ExecutionContext(
+                token_agent_id=token_agent_id,
+                jti=jti,
+                client_ip=client_ip,
+                request_id=request_id,
+            ),
+            timeout_seconds=30,
         )
-        if not agent:
-            logger.warning(
-                f"No active agent found for tool {tool.name}",
-                extra={
-                    "tool_id": str(tool.id),
-                    "org_id": str(tool.organization.id),
-                    "env_id": str(tool.environment.id),
-                },
-            )
-            return {"status": "error", "error": "no_active_agent"}
 
-    # PEP: Policy Enforcement Point - check policy BEFORE tool execution (deny-by-default)
-    # P0: Pass audit metadata (jti, ip, request_id) for forensics
-    allowed, deny_reason = check_policy_before_tool_call(
-        agent_id=str(agent.id),
-        tool=tool,
-        payload=payload,
-        jti=jti,
-        client_ip=client_ip,
-        request_id=request_id,
-    )
-    if not allowed:
-        logger.warning(
-            f"PEP denied tool execution: {tool.name}",
-            extra={
-                "agent_id": str(agent.id),
-                "tool_id": str(tool.id),
-                "reason": deny_reason,
-            },
-        )
-        return {
-            "status": "error",
-            "error": "policy_denied",
-            "error_description": deny_reason or "Policy denied",
-        }
-
-    # Start run (uses our security: Policy, Schema, Rate, Timeout, Audit)
-    # Note: start_run also checks policy, but PEP check is explicit for MCP calls
-    try:
-        run = start_run(agent=agent, tool=tool, input_json=payload, timeout_seconds=30)
-
-        if run.status == "succeeded":
+        if result["status"] == "succeeded":
             return {
                 "status": "success",
-                "output": run.output_json,
-                "run_id": str(run.id),
+                "output": result,
+                "run_id": result["run_id"],
             }
 
         return {
             "status": "error",
-            "error": run.error_text or "execution_failed",
-            "run_id": str(run.id),
+            "error": result["content"][0]["text"] if result.get("content") else "execution_failed",
+            "run_id": result.get("run_id"),
         }
     except Exception as e:
         # Don't leak internal details
+        error_text = str(e)
+        if "Agent mismatch" in error_text:
+            return {
+                "status": "error",
+                "error": "agent_session_mismatch",
+                "error_description": error_text,
+            }
+        if "not found" in error_text:
+            return {"status": "error", "error": "agent_not_found"}
+        if "Policy denied" in error_text:
+            return {
+                "status": "error",
+                "error": "policy_denied",
+                "error_description": error_text,
+            }
+
         logger.error(
             f"Error executing tool {tool.name} via AgentxSuite",
             extra={
                 "tool_id": str(tool.id),
-                "agent_id": str(agent.id),
+                "agent_id": token_agent_id or agent_id,
                 "error_type": type(e).__name__,
             },
             exc_info=True,

--- a/backend/mcp_fabric/jsonrpc.py
+++ b/backend/mcp_fabric/jsonrpc.py
@@ -1,0 +1,225 @@
+"""
+Shared JSON-RPC handling for AgentxSuite MCP transports.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from asgiref.sync import sync_to_async
+
+from apps.agents.models import Agent
+from apps.runs.services import ExecutionContext, execute_tool_run
+from apps.tenants.models import Environment, Organization
+from mcp_fabric.registry import get_tools_list_for_org_env
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_mcp_tool_name(name: str) -> str:
+    """Normalize tool names to the MCP-compatible pattern."""
+    normalized = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return normalized[:64] or "unnamed_tool"
+
+
+@dataclass
+class MCPJsonRpcContext:
+    """Tenant and token context resolved before handling JSON-RPC messages."""
+
+    organization: Organization
+    environment: Environment
+    token_claims: dict[str, Any]
+    agent: Agent | None = None
+    server_name: str = "agentxsuite"
+
+
+class MCPJsonRpcHandler:
+    """Handle MCP JSON-RPC methods independent of the transport."""
+
+    def __init__(self, context: MCPJsonRpcContext):
+        self.context = context
+        self.initialized = False
+
+    async def handle_message(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        """Route a single JSON-RPC request or notification."""
+        msg_id = message.get("id")
+        method = message.get("method")
+
+        if msg_id is None:
+            logger.debug("Received MCP notification: %s", method)
+            return None
+
+        try:
+            if method == "initialize":
+                return await self.handle_initialize(message)
+            if method == "tools/list":
+                return await self.handle_tools_list(message)
+            if method == "tools/call":
+                return await self.handle_tool_call(message)
+            if method == "resources/list":
+                return self._success_response(msg_id, {"resources": []})
+            if method == "prompts/list":
+                return self._success_response(msg_id, {"prompts": []})
+
+            return self._error_response(
+                msg_id,
+                -32601,
+                "Method not found",
+                f"Unknown method: {method}",
+            )
+        except Exception as exc:
+            logger.error("Error handling MCP method %s", method, exc_info=True)
+            return self._error_response(
+                msg_id,
+                -32603,
+                "Internal error",
+                str(exc),
+            )
+
+    async def handle_initialize(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Return server capabilities for MCP initialization."""
+        msg_id = message.get("id")
+        params = message.get("params", {})
+        protocol_version = params.get("protocolVersion", "2024-11-05")
+        self.initialized = True
+
+        return self._success_response(
+            msg_id,
+            {
+                "protocolVersion": protocol_version,
+                "capabilities": {
+                    "tools": {},
+                    "resources": {},
+                    "prompts": {},
+                },
+                "serverInfo": {
+                    "name": self.context.server_name,
+                    "version": "1.0.0",
+                },
+            },
+        )
+
+    async def handle_tools_list(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Return enabled tools for the resolved organization/environment."""
+        msg_id = message.get("id")
+        tools = await sync_to_async(get_tools_list_for_org_env)(
+            org=self.context.organization,
+            env=self.context.environment,
+        )
+
+        normalized_tools = []
+        for tool in tools:
+            original_name = tool.get("name", "")
+            normalized_tool = {**tool, "name": self._normalize_tool_name(original_name)}
+            if not normalized_tool.get("description"):
+                normalized_tool["description"] = f"Tool: {original_name}"
+            normalized_tools.append(normalized_tool)
+
+        return self._success_response(msg_id, {"tools": normalized_tools})
+
+    async def handle_tool_call(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Execute a tool using MCP params `{name, arguments}`."""
+        msg_id = message.get("id")
+        params = message.get("params") or {}
+        tool_name = params.get("name")
+        arguments = params.get("arguments") or {}
+
+        if not tool_name:
+            return self._error_response(
+                msg_id,
+                -32602,
+                "Invalid params",
+                "Missing 'name' parameter",
+            )
+
+        if not isinstance(arguments, dict):
+            return self._error_response(
+                msg_id,
+                -32602,
+                "Invalid params",
+                "'arguments' must be an object",
+            )
+
+        try:
+            result = await sync_to_async(execute_tool_run)(
+                organization=self.context.organization,
+                environment=self.context.environment,
+                tool_identifier=tool_name,
+                agent_identifier=None,
+                input_data=arguments,
+                context=ExecutionContext.from_token_claims(self.context.token_claims),
+            )
+        except ValueError as exc:
+            message_text = str(exc)
+            if "not found" in message_text.lower():
+                return self._error_response(msg_id, -32602, "Tool not found", message_text)
+
+            return self._success_response(
+                msg_id,
+                {
+                    "content": [{"type": "text", "text": message_text}],
+                    "isError": True,
+                },
+            )
+
+        return self._success_response(
+            msg_id,
+            {
+                "content": self._content_from_execution_result(result),
+                "isError": bool(result.get("isError")),
+            },
+        )
+
+    def _content_from_execution_result(self, result: dict[str, Any]) -> list[dict[str, str]]:
+        content = result.get("content")
+        if isinstance(content, list):
+            return content
+
+        if "output" in result:
+            return self._content_from_value(result["output"])
+        if "result" in result:
+            return self._content_from_value(result["result"])
+        if result:
+            return self._content_from_value(result)
+        return []
+
+    def _content_from_value(self, value: Any) -> list[dict[str, str]]:
+        if isinstance(value, str):
+            text = value
+        else:
+            text = json.dumps(value, indent=2)
+        return [{"type": "text", "text": text}]
+
+    def _normalize_tool_name(self, name: str) -> str:
+        return normalize_mcp_tool_name(name)
+
+    def _success_response(self, msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": result,
+        }
+
+    def _error_response(
+        self,
+        msg_id: Any,
+        code: int,
+        message: str,
+        data: Any = None,
+    ) -> dict[str, Any]:
+        error = {
+            "code": code,
+            "message": message,
+        }
+        if data is not None:
+            error["data"] = data
+
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": error,
+        }

--- a/backend/mcp_fabric/registry.py
+++ b/backend/mcp_fabric/registry.py
@@ -4,22 +4,43 @@ Registry for dynamically registering Django tools with fastmcp MCPServer.
 from __future__ import annotations
 
 import logging
-import types
 from typing import TYPE_CHECKING, Any
 
-from apps.tools.models import Tool
+from django.conf import settings
+
+from apps.tools.models import CuratedTool, Tool
 
 if TYPE_CHECKING:
     from fastmcp.server.server import FastMCP as MCPServer
+
     from apps.tenants.models import Environment, Organization
 
 logger = logging.getLogger(__name__)
 
 
+def _tool_curation_enabled() -> bool:
+    """Return whether curated tools should be exposed to MCP clients."""
+    return bool(getattr(settings, "TOOL_CURATION_ENABLED", False))
+
+
+def _agent_tool_mode() -> str:
+    """Return the configured agent-facing tool exposure mode."""
+    return getattr(settings, "AGENT_TOOL_MODE", "raw_only")
+
+
+def _tool_definition(name: str, description: str | None, input_schema: dict) -> dict:
+    """Build a MCP-compatible tool definition."""
+    return {
+        "name": name,
+        "description": description or f"Tool: {name}",
+        "inputSchema": input_schema or {"type": "object"},
+    }
+
+
 def get_tools_list_for_org_env(
     *,
-    org: "Organization",
-    env: "Environment",
+    org: Organization,
+    env: Environment,
 ) -> list[dict]:
     """
     Get list of available tools for organization/environment in MCP-compatible format.
@@ -44,21 +65,36 @@ def get_tools_list_for_org_env(
     """
     tools_list = []
     
-    # Get regular tools from database
-    tools = Tool.objects.filter(
-        organization=org, environment=env, enabled=True
-    ).select_related("connection")
-    
-    for tool in tools:
+    if _tool_curation_enabled() and _agent_tool_mode() != "raw_only":
+        curated_tools = CuratedTool.objects.filter(
+            organization=org,
+            environment=env,
+            enabled=True,
+        ).select_related("connection")
+
+        for tool in curated_tools:
+            tools_list.append(
+                _tool_definition(tool.name, tool.description, tool.schema_json)
+            )
+
+    if not _tool_curation_enabled() or _agent_tool_mode() == "raw_only":
+        raw_tools = Tool.objects.filter(
+            organization=org, environment=env, enabled=True
+        ).select_related("connection")
+    elif _agent_tool_mode() == "curated_and_raw":
+        raw_tools = Tool.objects.filter(
+            organization=org,
+            environment=env,
+            enabled=True,
+            is_agent_visible=True,
+        ).select_related("connection")
+    else:
+        raw_tools = Tool.objects.none()
+
+    for tool in raw_tools:
         input_schema = getattr(tool, "schema_json", None) or {"type": "object"}
         description = input_schema.get("description") if isinstance(input_schema, dict) else None
-        
-        tool_dict = {
-            "name": tool.name,
-            "description": description or f"Tool: {tool.name}",
-            "inputSchema": input_schema,
-        }
-        tools_list.append(tool_dict)
+        tools_list.append(_tool_definition(tool.name, description, input_schema))
     
     # Add system tools
     from apps.system_tools.tools import SYSTEM_TOOLS
@@ -75,10 +111,10 @@ def get_tools_list_for_org_env(
 
 
 def register_tools_for_org_env(
-    mcp: "MCPServer",
+    mcp: MCPServer,
     *,
-    org: "Organization",
-    env: "Environment",
+    org: Organization,
+    env: Environment,
 ) -> None:
     """
     Register all enabled tools for an organization/environment with fastmcp.
@@ -92,22 +128,21 @@ def register_tools_for_org_env(
         org: Organization instance
         env: Environment instance
     """
-    # Register regular tools
-    tools = Tool.objects.filter(
-        organization=org, environment=env, enabled=True
-    ).select_related("connection")
+    tools = _get_agent_executable_tools(org=org, env=env)
 
     for tool in tools:
         input_schema = getattr(tool, "schema_json", None) or {"type": "object"}
         description = input_schema.get("description") if isinstance(input_schema, dict) else None
-        version = getattr(tool, "version", None) or "1.0.0"
 
         # FastMCP doesn't support **kwargs, so we need to create a function
         # with explicit parameters matching the schema
         # We'll create a function that accepts all schema properties as optional parameters
-        schema_props = input_schema.get("properties", {}) if isinstance(input_schema, dict) else {}
-        
-        def create_handler(_t: Tool = tool, _schema: dict = input_schema):
+
+        def create_handler(
+            _t: Tool | CuratedTool = tool,
+            _schema: dict = input_schema,
+            _description: str | None = description,
+        ):
             # Create function code dynamically based on schema properties
             param_names = list(_schema.get("properties", {}).keys()) if isinstance(_schema, dict) else []
             
@@ -129,22 +164,22 @@ def register_tools_for_org_env(
                     "jti = payload.pop('_jti', None)",
                     "client_ip = payload.pop('_client_ip', None)",
                     "request_id = payload.pop('_request_id', None)",
-                    "from mcp_fabric.adapters import run_tool_via_agentxsuite",
-                    "return run_tool_via_agentxsuite(tool=_t, payload=payload, agent_id=agent_id, token_agent_id=token_agent_id, jti=jti, client_ip=client_ip, request_id=request_id)",
+                    "from apps.runs.services import ExecutionContext, execute_tool_run",
+                    "return execute_tool_run(organization=_t.organization, environment=_t.environment, tool_identifier=str(_t.id), agent_identifier=agent_id, input_data=payload, context=ExecutionContext(token_agent_id=token_agent_id, jti=jti, client_ip=client_ip, request_id=request_id))",
                 ])
                 # Join with proper indentation (4 spaces)
                 body_str = "\n    ".join(body_lines)
                 func_code = f"def _handler({params_str}) -> dict:\n    {body_str}"
             else:
                 # No parameters - empty function
-                func_code = "def _handler() -> dict:\n    payload = {}\n    agent_id = payload.pop('agent_id', None)\n    token_agent_id = payload.pop('_token_agent_id', None)\n    jti = payload.pop('_jti', None)\n    client_ip = payload.pop('_client_ip', None)\n    request_id = payload.pop('_request_id', None)\n    from mcp_fabric.adapters import run_tool_via_agentxsuite\n    return run_tool_via_agentxsuite(tool=_t, payload=payload, agent_id=agent_id, token_agent_id=token_agent_id, jti=jti, client_ip=client_ip, request_id=request_id)"
+                func_code = "def _handler() -> dict:\n    payload = {}\n    agent_id = payload.pop('agent_id', None)\n    token_agent_id = payload.pop('_token_agent_id', None)\n    jti = payload.pop('_jti', None)\n    client_ip = payload.pop('_client_ip', None)\n    request_id = payload.pop('_request_id', None)\n    from apps.runs.services import ExecutionContext, execute_tool_run\n    return execute_tool_run(organization=_t.organization, environment=_t.environment, tool_identifier=str(_t.id), agent_identifier=agent_id, input_data=payload, context=ExecutionContext(token_agent_id=token_agent_id, jti=jti, client_ip=client_ip, request_id=request_id))"
             
             # Execute function code in local namespace
             namespace = {"_t": _t, "Any": Any}
             exec(func_code, namespace)
             handler = namespace["_handler"]
             handler.__name__ = _t.name
-            handler.__doc__ = description or f"Tool: {_t.name}"
+            handler.__doc__ = _description or f"Tool: {_t.name}"
             return handler
 
         try:
@@ -153,7 +188,7 @@ def register_tools_for_org_env(
             
             # Register tool - FastMCP will infer parameters from function signature
             # and use the schema properties for validation
-            registered_tool = mcp.tool(
+            mcp.tool(
                 name=tool.name,
                 description=description or f"Tool: {tool.name}",
             )(handler)
@@ -181,10 +216,10 @@ def register_tools_for_org_env(
 
 
 def register_system_tools_for_org_env(
-    mcp: "MCPServer",
+    mcp: MCPServer,
     *,
-    org: "Organization",
-    env: "Environment",
+    org: Organization,
+    env: Environment,
 ) -> None:
     """
     Register system tools for an organization/environment.
@@ -196,8 +231,8 @@ def register_system_tools_for_org_env(
         org: Organization instance
         env: Environment instance
     """
-    from apps.system_tools.tools import SYSTEM_TOOLS
     from apps.system_tools.services import TOOL_HANDLERS
+    from apps.system_tools.tools import SYSTEM_TOOLS
     
     for tool_def in SYSTEM_TOOLS:
         tool_name = tool_def["name"]
@@ -222,12 +257,14 @@ def register_system_tools_for_org_env(
             _handler=handler_func,
             _org=org,
             _env=env,
+            _param_names=param_names,
+            _tool_name=tool_name,
         ):
             # Build parameter string including metadata params (will be filtered out)
-            all_params = param_names + ["_token_agent_id", "_jti", "_client_ip", "_request_id"]
+            all_params = _param_names + ["_token_agent_id", "_jti", "_client_ip", "_request_id"]
             params_str = ", ".join([f"{name}: Any = None" for name in all_params])
             
-            if param_names:
+            if _param_names:
                 body_lines = [
                     "payload = {}",
                     "# Extract metadata params from function parameters",
@@ -237,23 +274,23 @@ def register_system_tools_for_org_env(
                     "request_id = _request_id if '_request_id' in locals() else None",
                 ]
                 # Only add schema-defined parameters to payload
-                for name in param_names:
+                for name in _param_names:
                     body_lines.append(f"if {name} is not None: payload['{name}'] = {name}")
                 body_lines.extend([
                     f"payload['organization_id'] = '{_org.id}'",
                     f"payload['environment_id'] = '{_env.id}'",
-                    f"from apps.system_tools.services import run_system_tool_with_audit, TOOL_HANDLERS",
-                    f"return run_system_tool_with_audit(",
-                    f"    tool_name='{tool_name}',",
-                    f"    handler=TOOL_HANDLERS['{tool_name}'],",
-                    f"    payload=payload,",
+                    "from apps.system_tools.services import run_system_tool_with_audit, TOOL_HANDLERS",
+                    "return run_system_tool_with_audit(",
+                    f"    tool_name='{_tool_name}',",
+                    f"    handler=TOOL_HANDLERS['{_tool_name}'],",
+                    "    payload=payload,",
                     f"    organization_id='{_org.id}',",
                     f"    environment_id='{_env.id}',",
-                    f"    token_agent_id=token_agent_id,",
-                    f"    jti=jti,",
-                    f"    client_ip=client_ip,",
-                    f"    request_id=request_id,",
-                    f")",
+                    "    token_agent_id=token_agent_id,",
+                    "    jti=jti,",
+                    "    client_ip=client_ip,",
+                    "    request_id=request_id,",
+                    ")",
                 ])
                 body_str = "\n    ".join(body_lines)
                 func_code = f"def _system_handler({params_str}) -> dict:\n    {body_str}"
@@ -265,8 +302,8 @@ def register_system_tools_for_org_env(
     payload['environment_id'] = '{_env.id}'
     from apps.system_tools.services import run_system_tool_with_audit, TOOL_HANDLERS
     return run_system_tool_with_audit(
-        tool_name='{tool_name}',
-        handler=TOOL_HANDLERS['{tool_name}'],
+        tool_name='{_tool_name}',
+        handler=TOOL_HANDLERS['{_tool_name}'],
         payload=payload,
         organization_id='{_org.id}',
         environment_id='{_env.id}',
@@ -285,7 +322,7 @@ def register_system_tools_for_org_env(
         
         try:
             handler = create_system_handler()
-            registered_tool = mcp.tool(
+            mcp.tool(
                 name=tool_name,
                 description=tool_def["description"],
             )(handler)
@@ -308,3 +345,38 @@ def register_system_tools_for_org_env(
                 exc_info=True,
             )
 
+
+def _get_agent_executable_tools(*, org: Organization, env: Environment):
+    """Return raw and/or curated tool objects that should be registered for agents."""
+    if _tool_curation_enabled() and _agent_tool_mode() != "raw_only":
+        curated_tools = list(
+            CuratedTool.objects.filter(
+                organization=org,
+                environment=env,
+                enabled=True,
+            ).select_related("connection")
+        )
+    else:
+        curated_tools = []
+
+    if not _tool_curation_enabled() or _agent_tool_mode() == "raw_only":
+        raw_tools = list(
+            Tool.objects.filter(
+                organization=org,
+                environment=env,
+                enabled=True,
+            ).select_related("connection")
+        )
+    elif _agent_tool_mode() == "curated_and_raw":
+        raw_tools = list(
+            Tool.objects.filter(
+                organization=org,
+                environment=env,
+                enabled=True,
+                is_agent_visible=True,
+            ).select_related("connection")
+        )
+    else:
+        raw_tools = []
+
+    return [*curated_tools, *raw_tools]

--- a/backend/mcp_fabric/settings.py
+++ b/backend/mcp_fabric/settings.py
@@ -40,6 +40,7 @@ AUTHORIZATION_SERVERS = config(
 
 # Supported scopes for MCP Fabric
 SCOPES_SUPPORTED = [
+    "mcp:connect",  # Establish Streamable HTTP/SSE sessions
     "mcp:manifest",  # Access to manifest endpoint
     "mcp:tools",  # Access to tools listing
     "mcp:run",  # Access to tool execution

--- a/backend/mcp_fabric/stdio_adapter.py
+++ b/backend/mcp_fabric/stdio_adapter.py
@@ -31,10 +31,8 @@ from asgiref.sync import sync_to_async
 
 from apps.agents.models import Agent
 from apps.tenants.models import Environment, Organization
-from mcp_fabric.adapters import run_tool_via_agentxsuite
 from mcp_fabric.deps import get_validated_token
-from mcp_fabric.errors import ErrorCodes
-from mcp_fabric.registry import get_tools_list_for_org_env
+from mcp_fabric.jsonrpc import MCPJsonRpcContext, MCPJsonRpcHandler, normalize_mcp_tool_name
 
 # Configure logging to stderr only
 logging.basicConfig(
@@ -65,6 +63,7 @@ class StdioMCPAdapter:
         self.env: Environment | None = None
         self.agent: Agent | None = None
         self.token_claims: dict[str, Any] | None = None
+        self.handler: MCPJsonRpcHandler | None = None
         self.initialized = False
 
     async def start(self):
@@ -165,14 +164,41 @@ class StdioMCPAdapter:
                     logger.warning(f"Agent {agent_id} not found, will auto-select")
             
             logger.info(f"Validated token for org={self.org.name}, env={self.env.name}")
+            self.handler = self._build_handler()
             
         except Exception as e:
             logger.error(f"Token validation failed: {e}")
             raise
 
+    def _build_handler(self) -> MCPJsonRpcHandler:
+        """Build the shared JSON-RPC handler for this stdio session."""
+        if not self.org or not self.env or self.token_claims is None:
+            raise ValueError("Organization/Environment not set")
+
+        resolved_agent_id = str(self.agent.id) if self.agent else self.token_claims.get("agent_id")
+        self.token_claims["_resolved_agent_id"] = resolved_agent_id
+        self.token_claims["_client_ip"] = None
+        self.token_claims["_jti"] = self.token_claims.get("_jti") or self.token_claims.get("jti")
+
+        return MCPJsonRpcHandler(
+            MCPJsonRpcContext(
+                organization=self.org,
+                environment=self.env,
+                agent=self.agent,
+                token_claims=self.token_claims,
+                server_name="agentxsuite",
+            )
+        )
+
+    def _get_handler(self) -> MCPJsonRpcHandler:
+        """Return the shared JSON-RPC handler, creating it for test-initialized adapters."""
+        if self.handler is None:
+            self.handler = self._build_handler()
+        return self.handler
+
     async def handle_message(self, message: dict) -> dict | None:
         """
-        Route JSON-RPC message to appropriate handler.
+        Route JSON-RPC message to the shared transport-independent handler.
         
         Args:
             message: JSON-RPC message
@@ -180,214 +206,35 @@ class StdioMCPAdapter:
         Returns:
             JSON-RPC response or None (for notifications)
         """
-        # Check if this is a notification (no id field)
-        is_notification = message.get("id") is None
-        
-        if is_notification:
-            logger.debug(f"Received notification: {message.get('method')}")
-            # Notifications don't require responses
-            return None
-        
-        method = message.get("method")
-        msg_id = message.get("id")
-        
-        try:
-            if method == "initialize":
-                return await self.handle_initialize(message)
-            elif method == "tools/list":
-                return await self.handle_tools_list(message)
-            elif method == "tools/call":
-                return await self.handle_tool_call(message)
-            elif method == "resources/list":
-                return await self.handle_resources_list(message)
-            elif method == "prompts/list":
-                return await self.handle_prompts_list(message)
-            else:
-                return self._error_response(
-                    msg_id,
-                    -32601,
-                    "Method not found",
-                    f"Unknown method: {method}",
-                )
-        except Exception as e:
-            logger.error(f"Error handling {method}: {e}", exc_info=True)
-            return self._error_response(
-                msg_id,
-                -32603,
-                "Internal error",
-                str(e),
-            )
+        response = await self._get_handler().handle_message(message)
+        self.initialized = self._get_handler().initialized
+        return response
 
     async def handle_initialize(self, message: dict) -> dict:
         """
-        Handle MCP initialize request.
+        Handle MCP initialize request via the shared JSON-RPC handler.
         
         Returns server capabilities and protocol version.
         """
-        msg_id = message.get("id")
-        params = message.get("params", {})
-        client_protocol_version = params.get("protocolVersion", "2024-11-05")
-        
-        self.initialized = True
-        
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {
-                "protocolVersion": client_protocol_version,
-                "capabilities": {
-                    "tools": {},  # We support tools
-                    "resources": {},  # We support resources
-                    "prompts": {},  # We support prompts
-                },
-                "serverInfo": {
-                    "name": "agentxsuite",
-                    "version": "1.0.0",
-                },
-            },
-        }
+        response = await self._get_handler().handle_initialize(message)
+        self.initialized = self._get_handler().initialized
+        return response
 
     async def handle_tools_list(self, message: dict) -> dict:
         """
-        Handle tools/list request.
+        Handle tools/list request via the shared JSON-RPC handler.
         
         Returns all enabled tools for the org/env.
         """
-        msg_id = message.get("id")
-        
-        if not self.org or not self.env:
-            return self._error_response(
-                msg_id,
-                -32603,
-                "Not initialized",
-                "Organization/Environment not set",
-            )
-        
-        try:
-            # Get tools from registry
-            tools = await sync_to_async(get_tools_list_for_org_env)(
-                org=self.org,
-                env=self.env,
-            )
-            
-            # Normalize tool names for MCP spec (^[a-zA-Z0-9_-]{1,64}$)
-            normalized_tools = []
-            for tool in tools:
-                original_name = tool.get("name", "")
-                normalized_name = self._normalize_tool_name(original_name)
-                
-                normalized_tool = {**tool, "name": normalized_name}
-                
-                # Ensure description exists
-                if "description" not in normalized_tool or not normalized_tool["description"]:
-                    normalized_tool["description"] = f"Tool: {original_name}"
-                
-                normalized_tools.append(normalized_tool)
-            
-            return {
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {
-                    "tools": normalized_tools,
-                },
-            }
-            
-        except Exception as e:
-            logger.error(f"Error listing tools: {e}", exc_info=True)
-            return self._error_response(
-                msg_id,
-                -32603,
-                "Internal error",
-                str(e),
-            )
+        return await self._get_handler().handle_tools_list(message)
 
     async def handle_tool_call(self, message: dict) -> dict:
         """
-        Handle tools/call request.
+        Handle tools/call request via the shared JSON-RPC handler.
         
         Executes a tool via AgentxSuite's run service with full security pipeline.
         """
-        msg_id = message.get("id")
-        params = message.get("params", {})
-        tool_name = params.get("name")
-        arguments = params.get("arguments", {})
-        
-        if not tool_name:
-            return self._error_response(
-                msg_id,
-                -32602,
-                "Invalid params",
-                "Missing 'name' parameter",
-            )
-        
-        try:
-            # Find tool by name
-            from apps.tools.models import Tool
-            
-            tool = await sync_to_async(
-                Tool.objects.filter(
-                    organization=self.org,
-                    environment=self.env,
-                    name=tool_name,
-                    enabled=True,
-                ).first
-            )()
-            
-            if not tool:
-                return self._error_response(
-                    msg_id,
-                    -32602,
-                    "Tool not found",
-                    f"Tool '{tool_name}' not found or not enabled",
-                )
-            
-            # Execute tool via AgentxSuite adapter
-            result = await sync_to_async(run_tool_via_agentxsuite)(
-                tool=tool,
-                payload=arguments,
-                agent_id=self.agent.id if self.agent else None,
-                token_agent_id=self.agent.id if self.agent else None,
-                jti=self.token_claims.get("jti"),
-                client_ip=None,  # Not available in stdio context
-                request_id=str(msg_id),
-            )
-            
-            # Convert result to MCP format
-            if result.get("status") == "success":
-                output = result.get("output", {})
-                # MCP expects content array
-                content = [{"type": "text", "text": json.dumps(output, indent=2)}]
-                
-                return {
-                    "jsonrpc": "2.0",
-                    "id": msg_id,
-                    "result": {
-                        "content": content,
-                        "isError": False,
-                    },
-                }
-            else:
-                error_msg = result.get("error", "Unknown error")
-                error_desc = result.get("error_description", error_msg)
-                content = [{"type": "text", "text": error_desc}]
-                
-                return {
-                    "jsonrpc": "2.0",
-                    "id": msg_id,
-                    "result": {
-                        "content": content,
-                        "isError": True,
-                    },
-                }
-                
-        except Exception as e:
-            logger.error(f"Error executing tool {tool_name}: {e}", exc_info=True)
-            return self._error_response(
-                msg_id,
-                -32603,
-                "Tool execution error",
-                str(e),
-            )
+        return await self._get_handler().handle_tool_call(message)
 
     async def handle_resources_list(self, message: dict) -> dict:
         """
@@ -395,15 +242,7 @@ class StdioMCPAdapter:
         
         Returns empty list for now (Phase 3).
         """
-        msg_id = message.get("id")
-        
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {
-                "resources": [],
-            },
-        }
+        return self._get_handler()._success_response(message.get("id"), {"resources": []})
 
     async def handle_prompts_list(self, message: dict) -> dict:
         """
@@ -411,15 +250,7 @@ class StdioMCPAdapter:
         
         Returns empty list for now (Phase 3).
         """
-        msg_id = message.get("id")
-        
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "result": {
-                "prompts": [],
-            },
-        }
+        return self._get_handler()._success_response(message.get("id"), {"prompts": []})
 
     def _normalize_tool_name(self, name: str) -> str:
         """
@@ -431,18 +262,7 @@ class StdioMCPAdapter:
         Returns:
             Normalized tool name
         """
-        import re
-        
-        # Replace invalid characters with underscore
-        normalized = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
-        # Collapse multiple underscores
-        normalized = re.sub(r"_+", "_", normalized)
-        # Remove leading/trailing underscores
-        normalized = normalized.strip("_")
-        # Limit to 64 characters
-        normalized = normalized[:64]
-        
-        return normalized or "unnamed_tool"
+        return normalize_mcp_tool_name(name)
 
     def _write_response(self, response: dict):
         """
@@ -478,18 +298,7 @@ class StdioMCPAdapter:
         Returns:
             JSON-RPC error response
         """
-        error = {
-            "code": code,
-            "message": message,
-        }
-        if data is not None:
-            error["data"] = data
-        
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "error": error,
-        }
+        return self._get_handler()._error_response(msg_id, code, message, data)
 
 
 async def main():

--- a/backend/mcp_fabric/tests/test_curation_registry.py
+++ b/backend/mcp_fabric/tests/test_curation_registry.py
@@ -1,0 +1,92 @@
+"""Tests for curated tool exposure through the MCP registry."""
+from __future__ import annotations
+
+import pytest
+from django.test import override_settings
+from model_bakery import baker
+
+from apps.connections.models import Connection
+from apps.tenants.models import Environment, Organization
+from apps.tools.models import CuratedTool, Tool
+from mcp_fabric.registry import get_tools_list_for_org_env
+
+
+@pytest.mark.django_db
+@override_settings(TOOL_CURATION_ENABLED=True, AGENT_TOOL_MODE="curated_only")
+def test_registry_lists_curated_tools_when_curation_enabled():
+    """Agent-facing MCP lists use CuratedTool when curation is enabled."""
+    org = baker.make(Organization, name="TestOrg")
+    env = baker.make(Environment, organization=org, name="dev", type="dev")
+    conn = baker.make(Connection, organization=org, environment=env, name="remote")
+    baker.make(
+        Tool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="raw_search",
+        enabled=True,
+        is_agent_visible=True,
+    )
+    baker.make(
+        CuratedTool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="search_docs",
+        display_name="Search Docs",
+        description="Search curated docs.",
+        schema_json={"type": "object", "properties": {"query": {"type": "string"}}},
+        curator_type="passthrough",
+        enabled=True,
+    )
+
+    tools = get_tools_list_for_org_env(org=org, env=env)
+    tool_names = {tool["name"] for tool in tools}
+
+    assert "search_docs" in tool_names
+    assert "raw_search" not in tool_names
+
+
+@pytest.mark.django_db
+@override_settings(TOOL_CURATION_ENABLED=True, AGENT_TOOL_MODE="curated_and_raw")
+def test_registry_lists_curated_and_agent_visible_raw_tools():
+    """Power users can expose selected raw tools alongside curated tools."""
+    org = baker.make(Organization, name="TestOrg")
+    env = baker.make(Environment, organization=org, name="dev", type="dev")
+    conn = baker.make(Connection, organization=org, environment=env, name="remote")
+    baker.make(
+        Tool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="visible_raw",
+        enabled=True,
+        is_agent_visible=True,
+    )
+    baker.make(
+        Tool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="hidden_raw",
+        enabled=True,
+        is_agent_visible=False,
+    )
+    baker.make(
+        CuratedTool,
+        organization=org,
+        environment=env,
+        connection=conn,
+        name="curated_search",
+        display_name="Curated Search",
+        curator_type="passthrough",
+        enabled=True,
+    )
+
+    tools = get_tools_list_for_org_env(org=org, env=env)
+    tool_names = {tool["name"] for tool in tools}
+
+    assert "curated_search" in tool_names
+    assert "visible_raw" in tool_names
+    assert "hidden_raw" not in tool_names
+

--- a/backend/mcp_fabric/tests/test_jsonrpc_handler.py
+++ b/backend/mcp_fabric/tests/test_jsonrpc_handler.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import mcp_fabric.jsonrpc as jsonrpc_module
+from mcp_fabric.jsonrpc import MCPJsonRpcContext, MCPJsonRpcHandler
+
+
+async def _call_sync(func, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+def _sync_to_async(func):
+    async def wrapper(*args, **kwargs):
+        return await _call_sync(func, *args, **kwargs)
+
+    return wrapper
+
+
+def test_tools_call_maps_mcp_name_arguments_to_execution_service(monkeypatch):
+    org = SimpleNamespace(id="org-id", name="Org")
+    env = SimpleNamespace(id="env-id", name="Env")
+    claims = {"_resolved_agent_id": "agent-id", "jti": "jti-1"}
+    handler = MCPJsonRpcHandler(
+        MCPJsonRpcContext(organization=org, environment=env, token_claims=claims)
+    )
+    execute_tool_run = Mock(
+        return_value={
+            "content": [{"type": "text", "text": "ok"}],
+            "isError": False,
+        },
+    )
+    monkeypatch.setattr(jsonrpc_module, "execute_tool_run", execute_tool_run)
+    monkeypatch.setattr(jsonrpc_module, "sync_to_async", lambda f: _sync_to_async(f))
+
+    response = asyncio.run(
+        handler.handle_tool_call(
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "search_docs",
+                    "arguments": {"query": "mcp"},
+                },
+            }
+        )
+    )
+
+    assert response["result"]["isError"] is False
+    execute_tool_run.assert_called_once()
+    call_kwargs = execute_tool_run.call_args.kwargs
+    assert call_kwargs["organization"] == org
+    assert call_kwargs["environment"] == env
+    assert call_kwargs["tool_identifier"] == "search_docs"
+    assert call_kwargs["agent_identifier"] is None
+    assert call_kwargs["input_data"] == {"query": "mcp"}
+
+
+def test_tools_call_rejects_non_object_arguments():
+    handler = MCPJsonRpcHandler(
+        MCPJsonRpcContext(
+            organization=SimpleNamespace(),
+            environment=SimpleNamespace(),
+            token_claims={},
+        )
+    )
+
+    response = asyncio.run(
+        handler.handle_tool_call(
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {"name": "search_docs", "arguments": "bad"},
+            }
+        )
+    )
+
+    assert response["error"]["code"] == -32602
+    assert "'arguments' must be an object" in response["error"]["data"]

--- a/backend/mcp_fabric/tests/test_stdio_adapter.py
+++ b/backend/mcp_fabric/tests/test_stdio_adapter.py
@@ -3,12 +3,11 @@ Tests for stdio MCP Adapter.
 """
 from __future__ import annotations
 
-import asyncio
-import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
+import mcp_fabric.jsonrpc as jsonrpc_module
 from apps.agents.models import Agent
 from apps.tenants.models import Environment, Organization
 from apps.tools.models import Tool
@@ -175,7 +174,7 @@ class TestStdioMCPAdapter:
             }
         ]
         
-        with patch("mcp_fabric.stdio_adapter.get_tools_list_for_org_env", return_value=mock_tools):
+        with patch("mcp_fabric.jsonrpc.get_tools_list_for_org_env", return_value=mock_tools):
             response = await adapter.handle_tools_list(message)
         
         assert response["jsonrpc"] == "2.0"
@@ -209,17 +208,11 @@ class TestStdioMCPAdapter:
         
         # Mock tool lookup and execution to avoid DB locks
         mock_result = {
-            "status": "success",
             "output": {"result": "test output"},
             "run_id": "test-run-id",
         }
-        
-        # Mock Tool.objects.filter().first() chain
-        mock_queryset = MagicMock()
-        mock_queryset.first = MagicMock(return_value=tool)
-        
-        with patch("apps.tools.models.Tool.objects.filter", return_value=mock_queryset), \
-             patch("mcp_fabric.stdio_adapter.run_tool_via_agentxsuite", return_value=mock_result):
+
+        with patch.object(jsonrpc_module, "execute_tool_run", return_value=mock_result):
             response = await adapter.handle_tool_call(message)
         
         assert response["jsonrpc"] == "2.0"
@@ -277,17 +270,11 @@ class TestStdioMCPAdapter:
         
         # Mock tool lookup and execution failure to avoid DB locks
         mock_result = {
-            "status": "error",
-            "error": "tool_execution_failed",
-            "error_description": "Tool execution failed for some reason",
+            "content": [{"type": "text", "text": "Tool execution failed for some reason"}],
+            "isError": True,
         }
-        
-        # Mock Tool.objects.filter().first() chain
-        mock_queryset = MagicMock()
-        mock_queryset.first = MagicMock(return_value=tool)
-        
-        with patch("apps.tools.models.Tool.objects.filter", return_value=mock_queryset), \
-             patch("mcp_fabric.stdio_adapter.run_tool_via_agentxsuite", return_value=mock_result):
+
+        with patch.object(jsonrpc_module, "execute_tool_run", return_value=mock_result):
             response = await adapter.handle_tool_call(message)
         
         assert response["jsonrpc"] == "2.0"

--- a/backend/mcp_gateway/Dockerfile
+++ b/backend/mcp_gateway/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy gateway code
+COPY __init__.py .
+COPY main.py .
+
+# Expose port
+EXPOSE 8091
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD python -c "import httpx; httpx.get('http://localhost:8091/health')"
+
+# Run gateway
+CMD ["python", "main.py"]
+

--- a/backend/mcp_gateway/README.md
+++ b/backend/mcp_gateway/README.md
@@ -1,0 +1,182 @@
+# MCP Gateway Service
+
+A server-side bridge that translates SSE/WebSocket connections from MCP clients (like Claude Desktop) to HTTP requests to the internal FastMCP server.
+
+## Architecture
+
+```
+Claude Desktop → SSE/WebSocket → MCP Gateway → HTTP → FastMCP Server
+   (User)         (Port 8091)      (This)      (Port 8090)
+```
+
+## Benefits
+
+- ✅ **No local bridge needed** - Users don't install anything
+- ✅ **Centralized** - All translation happens on your server
+- ✅ **Secure** - Token validation on server-side
+- ✅ **Scalable** - Can handle multiple concurrent connections
+
+## How it Works
+
+1. **Client connects** via SSE or WebSocket to `https://mcp.agentxsuite.com`
+2. **Gateway receives** MCP protocol messages (JSON-RPC)
+3. **Gateway translates** to HTTP calls to internal FastMCP server
+4. **Gateway returns** responses back to client
+
+## User Configuration
+
+Users only need to configure Claude Desktop once:
+
+```json
+{
+  "mcpServers": {
+    "agentxsuite": {
+      "url": "https://mcp.agentxsuite.com/.well-known/mcp/sse",
+      "transport": "sse",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+## Running
+
+### Development
+
+```bash
+cd backend
+python mcp_gateway/main.py
+```
+
+Service runs on http://localhost:8091
+
+### Production
+
+```bash
+# With systemd
+sudo systemctl start mcp-gateway
+
+# With Docker
+docker run -p 8091:8091 agentxsuite-mcp-gateway
+
+# Behind Nginx
+# Configure nginx to proxy https://mcp.agentxsuite.com to localhost:8091
+```
+
+## Endpoints
+
+- `GET /.well-known/mcp` - Discovery endpoint
+- `GET /.well-known/mcp/sse` - SSE transport endpoint
+- `WS /.well-known/mcp/ws` - WebSocket transport endpoint
+- `GET /health` - Health check
+
+## Dependencies
+
+```
+fastapi
+uvicorn[standard]
+httpx
+sse-starlette
+```
+
+## Configuration
+
+Environment variables:
+
+- `FASTMCP_BACKEND_URL` - Internal FastMCP server URL (default: http://localhost:8090)
+- `PORT` - Gateway port (default: 8091)
+- `LOG_LEVEL` - Logging level (default: info)
+
+## Security
+
+- All tokens are validated by the backend FastMCP server
+- Gateway only proxies requests, doesn't store credentials
+- HTTPS required in production
+- CORS configured to allow only your domains
+
+## Testing
+
+```bash
+# Test SSE endpoint
+curl -N -H "Authorization: Bearer TOKEN" \
+  http://localhost:8091/.well-known/mcp/sse
+
+# Test WebSocket
+wscat -c ws://localhost:8091/.well-known/mcp/ws \
+  -H "Authorization: Bearer TOKEN"
+```
+
+## Deployment
+
+### Nginx Configuration
+
+```nginx
+upstream mcp_gateway {
+    server localhost:8091;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name mcp.agentxsuite.com;
+
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    location /.well-known/mcp/sse {
+        proxy_pass http://mcp_gateway;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        chunked_transfer_encoding off;
+        proxy_buffering off;
+        proxy_cache off;
+    }
+
+    location /.well-known/mcp/ws {
+        proxy_pass http://mcp_gateway;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
+    location / {
+        proxy_pass http://mcp_gateway;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+### Systemd Service
+
+```ini
+[Unit]
+Description=AgentxSuite MCP Gateway
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/agentxsuite/backend
+Environment="PATH=/opt/agentxsuite/venv/bin"
+ExecStart=/opt/agentxsuite/venv/bin/python mcp_gateway/main.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Monitoring
+
+Gateway logs all requests with:
+- Request ID
+- Client IP
+- Response time
+- Error rates
+
+Use these logs for monitoring and debugging.
+

--- a/backend/mcp_gateway/__init__.py
+++ b/backend/mcp_gateway/__init__.py
@@ -1,0 +1,10 @@
+"""
+MCP Gateway - SSE/WebSocket to HTTP bridge for Claude Desktop.
+
+This module provides a gateway that accepts SSE/WebSocket connections
+from MCP clients (like Claude Desktop) and proxies them to the internal
+HTTP-based FastMCP server.
+
+This eliminates the need for users to run a local bridge.
+"""
+

--- a/backend/mcp_gateway/docker-compose.yml
+++ b/backend/mcp_gateway/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  mcp-gateway:
+    build: .
+    ports:
+      - "8091:8091"
+    environment:
+      - FASTMCP_BACKEND_URL=http://mcp-fabric:8090
+      - LOG_LEVEL=info
+    depends_on:
+      - mcp-fabric
+    networks:
+      - agentxsuite
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8091/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  mcp-fabric:
+    image: agentxsuite-mcp-fabric:latest
+    ports:
+      - "8090:8090"
+    networks:
+      - agentxsuite
+
+networks:
+  agentxsuite:
+    driver: bridge
+

--- a/backend/mcp_gateway/main.py
+++ b/backend/mcp_gateway/main.py
@@ -1,0 +1,352 @@
+"""MCP Gateway Service - Streamable HTTP entrypoint for MCP clients."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from typing import Any
+
+import django
+from asgiref.sync import sync_to_async
+from django.conf import settings
+from django.core.cache import cache
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect, status
+from fastapi.responses import JSONResponse, Response
+from sse_starlette.sse import EventSourceResponse
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.dev")
+django.setup()
+
+from mcp_fabric.agent_resolver import resolve_agent_from_token_claims
+from mcp_fabric.deps import get_validated_token, get_www_authenticate_header
+from mcp_fabric.errors import ErrorCodes, raise_mcp_http_exception
+from mcp_fabric.jsonrpc import MCPJsonRpcContext, MCPJsonRpcHandler
+from mcp_fabric.settings import MCP_CANONICAL_URI
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_STATE_CACHE_PREFIX = "mcp_gateway:session:"
+GATEWAY_STATE_TIMEOUT_SECONDS = getattr(settings, "MCP_GATEWAY_STATE_TIMEOUT_SECONDS", 3600)
+
+app = FastAPI(
+    title="AgentxSuite MCP Gateway",
+    description="Streamable HTTP MCP gateway for AgentxSuite",
+    version="1.0.0",
+)
+
+
+def _extract_bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise raise_mcp_http_exception(
+            ErrorCodes.MISSING_TOKEN,
+            "Missing Authorization header",
+            status.HTTP_401_UNAUTHORIZED,
+            headers=get_www_authenticate_header(),
+        )
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise raise_mcp_http_exception(
+            ErrorCodes.INVALID_TOKEN,
+            "Authorization header must use Bearer token",
+            status.HTTP_401_UNAUTHORIZED,
+            headers=get_www_authenticate_header(),
+        )
+
+    return token
+
+
+async def _validated_claims_from_request(request: Request) -> dict[str, Any]:
+    """Validate bearer token and attach resolved agent/audit metadata."""
+    token = _extract_bearer_token(request.headers.get("authorization"))
+    resource = request.query_params.get("resource") or MCP_CANONICAL_URI
+    claims = get_validated_token(token, required_scopes=["mcp:connect"], resource=resource)
+
+    org_id = claims.get("org_id")
+    env_id = claims.get("env_id")
+    if not org_id or not env_id:
+        raise raise_mcp_http_exception(
+            ErrorCodes.AGENT_NOT_FOUND,
+            "Token missing org_id or env_id claims",
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    resolved_agent = await sync_to_async(resolve_agent_from_token_claims)(
+        claims,
+        str(org_id),
+        str(env_id),
+    )
+    if not resolved_agent:
+        raise raise_mcp_http_exception(
+            ErrorCodes.AGENT_NOT_FOUND,
+            "Agent not found or access denied",
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    query_agent_id = request.query_params.get("agent_id")
+    if query_agent_id and query_agent_id != str(resolved_agent.id):
+        raise raise_mcp_http_exception(
+            ErrorCodes.AGENT_SESSION_MISMATCH,
+            "Agent cannot be changed during an MCP session",
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    client_ip = request.client.host if request.client else None
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        client_ip = forwarded_for.split(",", 1)[0].strip()
+
+    claims["_resolved_agent_id"] = str(resolved_agent.id)
+    claims["agent_id"] = str(resolved_agent.id)
+    claims["_client_ip"] = client_ip
+    claims["_request_id"] = request.headers.get("x-request-id") or str(uuid.uuid4())
+    claims["_jti"] = claims.get("jti")
+    claims["_gateway_session_key"] = _gateway_session_key(claims)
+    return claims
+
+
+async def _validated_claims_from_websocket(websocket: WebSocket) -> dict[str, Any]:
+    token = _extract_bearer_token(websocket.headers.get("authorization"))
+    claims = get_validated_token(token, required_scopes=["mcp:connect"], resource=MCP_CANONICAL_URI)
+
+    org_id = claims.get("org_id")
+    env_id = claims.get("env_id")
+    if not org_id or not env_id:
+        raise ValueError("Token missing org_id or env_id claims")
+
+    resolved_agent = await sync_to_async(resolve_agent_from_token_claims)(
+        claims,
+        str(org_id),
+        str(env_id),
+    )
+    if not resolved_agent:
+        raise ValueError("Agent not found or access denied")
+
+    claims["_resolved_agent_id"] = str(resolved_agent.id)
+    claims["agent_id"] = str(resolved_agent.id)
+    claims["_client_ip"] = websocket.client.host if websocket.client else None
+    claims["_request_id"] = str(uuid.uuid4())
+    claims["_jti"] = claims.get("jti")
+    claims["_gateway_session_key"] = _gateway_session_key(claims)
+    return claims
+
+
+def _gateway_session_key(token_claims: dict[str, Any]) -> str:
+    """Build a stable cache key for gateway session state."""
+    session_id = (
+        token_claims.get("jti")
+        or token_claims.get("_resolved_agent_id")
+        or token_claims.get("agent_id")
+        or token_claims.get("sub")
+        or str(uuid.uuid4())
+    )
+    return f"{GATEWAY_STATE_CACHE_PREFIX}{session_id}"
+
+
+async def _load_gateway_state(session_key: str | None) -> dict[str, Any]:
+    """Load gateway session state from the configured Django cache backend."""
+    if not session_key:
+        return {}
+    state_data = await sync_to_async(cache.get)(session_key)
+    return state_data if isinstance(state_data, dict) else {}
+
+
+async def _save_gateway_state(handler: MCPJsonRpcHandler) -> None:
+    """Persist lightweight handler state for multi-instance gateways."""
+    session_key = handler.context.token_claims.get("_gateway_session_key")
+    if not session_key:
+        return
+
+    await sync_to_async(cache.set)(
+        session_key,
+        {"initialized": handler.initialized},
+        GATEWAY_STATE_TIMEOUT_SECONDS,
+    )
+
+
+async def _build_handler(token_claims: dict[str, Any]) -> MCPJsonRpcHandler:
+    from apps.agents.models import Agent
+    from apps.tenants.models import Environment, Organization
+
+    org_id = token_claims.get("org_id")
+    env_id = token_claims.get("env_id")
+    agent_id = token_claims.get("_resolved_agent_id") or token_claims.get("agent_id")
+
+    org = await sync_to_async(Organization.objects.get)(id=org_id)
+    env = await sync_to_async(Environment.objects.get)(id=env_id, organization=org)
+    agent = None
+    if agent_id:
+        agent = await sync_to_async(
+            Agent.objects.filter(
+                id=agent_id,
+                organization=org,
+                environment=env,
+                enabled=True,
+            ).first
+        )()
+
+    handler = MCPJsonRpcHandler(
+        MCPJsonRpcContext(
+            organization=org,
+            environment=env,
+            agent=agent,
+            token_claims=token_claims,
+            server_name=f"AgentxSuite MCP - {org.name}/{env.name}",
+        )
+    )
+    state_data = await _load_gateway_state(token_claims.get("_gateway_session_key"))
+    handler.initialized = bool(state_data.get("initialized", False))
+    return handler
+
+
+async def _handle_jsonrpc_payload(
+    handler: MCPJsonRpcHandler,
+    payload: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, Any] | list[dict[str, Any]] | None:
+    if isinstance(payload, list):
+        responses = []
+        for message in payload:
+            response = await handler.handle_message(message)
+            await _save_gateway_state(handler)
+            if response is not None:
+                responses.append(response)
+        return responses or None
+
+    response = await handler.handle_message(payload)
+    await _save_gateway_state(handler)
+    return response
+
+
+def _wants_event_stream(request: Request) -> bool:
+    accept = request.headers.get("accept", "")
+    return "text/event-stream" in accept.lower()
+
+
+@app.get("/.well-known/mcp")
+async def mcp_endpoint_get(request: Request):
+    """
+    Streamable HTTP GET opens a server-to-client event stream.
+
+    Non-SSE clients still receive a small discovery document for compatibility.
+    """
+    if _wants_event_stream(request):
+        await _validated_claims_from_request(request)
+
+        async def event_generator():
+            while True:
+                await asyncio.sleep(30)
+                yield {"event": "ping", "data": "{}"}
+
+        return EventSourceResponse(event_generator())
+
+    return {
+        "version": "1.0.0",
+        "transports": {
+            "streamable_http": {
+                "url": "/.well-known/mcp",
+            },
+            "sse": {
+                "url": "/.well-known/mcp/sse"
+            },
+            "websocket": {
+                "url": "/.well-known/mcp/ws"
+            }
+        }
+    }
+
+
+@app.post("/.well-known/mcp")
+async def mcp_streamable_http(request: Request):
+    """
+    Handle MCP JSON-RPC over Streamable HTTP.
+
+    The gateway validates the bearer token server-side and executes
+    tools/call directly via AgentxSuite's run service.
+    """
+    token_claims = await _validated_claims_from_request(request)
+    payload = await request.json()
+    handler = await _build_handler(token_claims)
+    response_payload = await _handle_jsonrpc_payload(handler, payload)
+
+    if response_payload is None:
+        return Response(status_code=status.HTTP_202_ACCEPTED)
+
+    if _wants_event_stream(request):
+        async def event_generator():
+            yield {
+                "event": "message",
+                "data": json.dumps(response_payload),
+            }
+
+        return EventSourceResponse(event_generator())
+
+    return JSONResponse(response_payload)
+
+
+@app.get("/.well-known/mcp/sse")
+async def mcp_sse(request: Request):
+    """
+    Legacy SSE endpoint for MCP clients that still use SSE + messages.
+    """
+    await _validated_claims_from_request(request)
+
+    async def event_generator():
+        base_url = str(request.base_url).rstrip("/")
+        yield {
+            "event": "endpoint",
+            "data": f"{base_url}/.well-known/mcp/messages",
+        }
+        while True:
+            await asyncio.sleep(30)
+            yield {"event": "ping", "data": "{}"}
+
+    return EventSourceResponse(event_generator())
+
+
+@app.post("/.well-known/mcp/messages")
+async def mcp_sse_messages(request: Request):
+    """Handle JSON-RPC messages for legacy SSE clients."""
+    return await mcp_streamable_http(request)
+
+
+@app.websocket("/.well-known/mcp/ws")
+async def mcp_websocket(websocket: WebSocket):
+    """
+    WebSocket compatibility endpoint using the same JSON-RPC handler.
+    """
+    try:
+        token_claims = await _validated_claims_from_websocket(websocket)
+        handler = await _build_handler(token_claims)
+        await websocket.accept()
+
+        while True:
+            message = await websocket.receive_json()
+            response = await _handle_jsonrpc_payload(handler, message)
+            if response is not None:
+                await websocket.send_json(response)
+    except WebSocketDisconnect:
+        logger.info("WebSocket disconnected")
+    except HTTPException as exc:
+        await websocket.close(code=1008, reason=str(exc.detail))
+    except Exception as e:
+        logger.error(f"WebSocket error: {e}")
+        await websocket.close(code=1011, reason=str(e))
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint."""
+    return {"status": "ok", "service": "mcp-gateway"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8091,  # Different port from FastMCP server
+        log_level="info"
+    )
+

--- a/backend/mcp_gateway/requirements.txt
+++ b/backend/mcp_gateway/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.109.0
+uvicorn[standard]>=0.27.0
+httpx>=0.26.0
+sse-starlette>=2.0.0
+python-multipart>=0.0.6
+

--- a/backend/mcp_gateway/tests/test_streamable_http.py
+++ b/backend/mcp_gateway/tests/test_streamable_http.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+import mcp_gateway.main as gateway_module
+from mcp_gateway.main import app
+
+
+class FakeHandler:
+    def __init__(self):
+        self.initialized = False
+        self.context = SimpleNamespace(token_claims={"_gateway_session_key": "test-session"})
+
+    async def handle_message(self, message):
+        if message.get("method") == "initialize":
+            self.initialized = True
+        if message.get("id") is None:
+            return None
+        return {
+            "jsonrpc": "2.0",
+            "id": message["id"],
+            "result": {"method": message["method"]},
+        }
+
+
+def test_streamable_http_post_returns_jsonrpc_response(monkeypatch):
+    async def validated_claims(_request):
+        return {"org_id": "org-id", "env_id": "env-id", "_resolved_agent_id": "agent-id"}
+
+    async def build_handler(_claims):
+        return FakeHandler()
+
+    monkeypatch.setattr(gateway_module, "_validated_claims_from_request", validated_claims)
+    monkeypatch.setattr(gateway_module, "_build_handler", build_handler)
+
+    client = TestClient(app)
+    response = client.post(
+        "/.well-known/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        headers={"Authorization": "Bearer test"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"method": "tools/list"},
+    }
+
+
+def test_streamable_http_post_returns_accepted_for_notifications(monkeypatch):
+    async def validated_claims(_request):
+        return {"org_id": "org-id", "env_id": "env-id", "_resolved_agent_id": "agent-id"}
+
+    async def build_handler(_claims):
+        return FakeHandler()
+
+    monkeypatch.setattr(gateway_module, "_validated_claims_from_request", validated_claims)
+    monkeypatch.setattr(gateway_module, "_build_handler", build_handler)
+
+    client = TestClient(app)
+    response = client.post(
+        "/.well-known/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers={"Authorization": "Bearer test"},
+    )
+
+    assert response.status_code == 202
+    assert response.content == b""
+
+
+def test_streamable_http_persists_initialized_state(monkeypatch):
+    gateway_module.cache.delete("test-session")
+
+    async def validated_claims(_request):
+        return {
+            "org_id": "org-id",
+            "env_id": "env-id",
+            "_resolved_agent_id": "agent-id",
+            "_gateway_session_key": "test-session",
+        }
+
+    async def build_handler(_claims):
+        return FakeHandler()
+
+    monkeypatch.setattr(gateway_module, "_validated_claims_from_request", validated_claims)
+    monkeypatch.setattr(gateway_module, "_build_handler", build_handler)
+
+    client = TestClient(app)
+    response = client.post(
+        "/.well-known/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+        headers={"Authorization": "Bearer test"},
+    )
+
+    assert response.status_code == 200
+    assert gateway_module.cache.get("test-session") == {"initialized": True}


### PR DESCRIPTION
## Purpose
Expose AgentxSuite as a real MCP server (JSON-RPC) with server-side token validation, using one shared handler across transports. Replaces closed PR #4 (its base branch was deleted on merge of #3).

## Changes
- mcp_fabric: shared `jsonrpc` handler (initialize/tools.list/tools.call), curated-tool aware registry, slimmer `stdio_adapter`/`adapters`
- mcp_gateway: Streamable HTTP MCP server (POST JSON-RPC + SSE), bearer token validation, agent resolution, cache-backed session state, WebSocket/legacy-SSE compatibility; Dockerfile/compose/README
- wire fabric/gateway routes in `config/urls.py`; deployment guide

## Tests
- mcp_fabric/tests: jsonrpc_handler, curation_registry, stdio_adapter
- mcp_gateway/tests: streamable_http

## Note
Base: main (after #3 merged). Merge before PR #5.